### PR TITLE
Re-arrange dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ typer = {version = "^0.6.1", extras = ["all"]}
 pygments = "^2.13.0"
 dependency-injector = {version = "^4.40.0", extras = ["yaml"]}
 pydantic = "^1.10.2"
-pre-commit = "^2.20.0"
 jinja2 = "^3.1.2"
 
 [tool.pytest.ini_options]
@@ -37,6 +36,7 @@ black = "^22.10.0"
 identify = "^2.5.7"
 poethepoet = "^0.16.4"
 python-semantic-release = "^7.33.1"
+pre-commit = "^2.20.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
* Moving pre-commit to dev dependencies
* The way pre-commit is configured in secureli, it actually uses the pre-commit tool installed the users device, so it's not really necessary for it to be in the virtual environment. Ideally we want it to fail in the virtual environment if it's not on a users device because it is currently implemented using Python subprocess. As such, I think it makes sense to move it to dev dependencies so that we only install the necessary tools in the virtual env, especially for homebrew
* Jira Story - https://slalom.atlassian.net/jira/software/c/projects/STFT/boards/2704?modal=detail&selectedIssue=STFT-136


List of required dependencies with pre-commit in the required dependencies group group

![image](https://user-images.githubusercontent.com/7746396/228033210-3000a2ec-acf4-4f40-8e9e-d8742860f28d.png)


List of required dependencies after I moved pre-commit to dev dependencies, which through testing is minimum dependencies we need for the homebrew formula to work as expected. This change also saves 10+ minutes from the install time since pre-commit actually brings down a lot of other packages with it


<img width="1071" alt="image" src="https://user-images.githubusercontent.com/7746396/228033071-0952e2c4-d8b2-460d-a253-e14e16ebca12.png">
