### PR TITLE
fix: Resolves setting save failure on empty secureli.yaml

### DIFF
--- a/secureli/repositories/settings.py
+++ b/secureli/repositories/settings.py
@@ -152,7 +152,8 @@ class SecureliRepository:
         }
 
         # Converts EchoLevel to string
-        settings_dict["echo"]["level"] = "{}".format(settings_dict["echo"]["level"])
+        if settings_dict.get("echo"):
+            settings_dict["echo"]["level"] = "{}".format(settings_dict["echo"]["level"])
 
         with open(self.secureli_file_path, "w") as f:
             yaml.dump(settings_dict, f)


### PR DESCRIPTION
#77 Bugfix for failing to write ignore rule to .secureli.yml when it does not exist yet

Note that this PR is for Github issue #77 and not Jira ticket STFT-077.  Branch was named as such to pass branch validation until branch validation has been updated.

Adds conditional logic so that saving the settings file does not attempt to modify the echo property if there is no echo property.