### PR TITLE
chore: Add pre-commit as dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -516,7 +516,7 @@ yaml = ["pyyaml"]
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 files = [
@@ -567,7 +567,7 @@ test = ["pytest (>=6)"]
 name = "filelock"
 version = "3.11.0"
 description = "A platform independent file lock."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -613,7 +613,7 @@ gitdb = ">=4.0.1,<5"
 name = "identify"
 version = "2.5.22"
 description = "File identification library for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -845,7 +845,7 @@ files = [
 name = "nodeenv"
 version = "1.7.0"
 description = "Node.js virtual environment builder"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
 files = [
@@ -911,7 +911,7 @@ testing = ["pytest", "pytest-cov"]
 name = "platformdirs"
 version = "3.2.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -962,7 +962,7 @@ poetry-plugin = ["poetry (>=1.0,<2.0)"]
 name = "pre-commit"
 version = "2.21.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1336,7 +1336,7 @@ files = [
 name = "setuptools"
 version = "67.6.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1511,7 +1511,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 name = "virtualenv"
 version = "20.21.0"
 description = "Virtual Python Environment builder"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1574,4 +1574,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a75faff0941c55b9ed7bf8fb9433bf7a629d2e0e31f9ad2f7fdc62611748adca"
+content-hash = "8d7ca1db0034d5aded34423ac25a99554702d1a22a285eaa8e5e1514c02d4fe2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ pydantic = "^1.10.2"
 jinja2 = "^3.1.2"
 pathspec = "^0.10.1"
 cfgv = "^3.3.1"
+pre-commit = "^2.20.0"
 
 [tool.pytest.ini_options]
 addopts = "-p no:cacheprovider"
@@ -40,7 +41,6 @@ black = "^22.10.0"
 identify = "^2.5.7"
 poethepoet = "^0.16.4"
 python-semantic-release = "^7.33.1"
-pre-commit = "^2.20.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/get-secureli-dependencies.py
+++ b/scripts/get-secureli-dependencies.py
@@ -12,9 +12,21 @@ secureliSha256 = os.getenv("secureliSha256")
 secureliPackageUrl = f"https://github.com/slalombuild/secureli/releases/download/v{secureliVersion}/secureli-{secureliVersion}.tar.gz"
 secureliPackageDependencies = []
 secureliFormulaPath = "./homebrew-secureli/Formula"
-# Poetry does not do a good job of filtering out package sub-dependencies
-# As a result, we need to filter out the packages ourself that the Secureli Formula does not need
-packagesToRemoveFromFormula = ["colorama", "six", "shellingham"]
+# Filter out additional packages that are needed for the pip package, but not the homebrew formula
+packagesToRemoveFromFormula = [
+    "colorama",
+    "six",
+    "shellingham",
+    "distlib",
+    "filelock",
+    "identify",
+    "nodeenv",
+    "platformdirs",
+    "setuptools",
+    "virtualenv",
+    "cfgv",
+    "pre-commit",
+]
 
 secureliPackageNamesCmd = "poetry show --only main | awk '{print $1}'"
 secureliPackageVersionsCmd = "poetry show --only main | awk '{print $2}'"


### PR DESCRIPTION
Fixes - https://github.com/slalombuild/secureli/issues/80

Resolution

* Move pre-commit to being a required dependency. This should force the pip installation to pull that package down
* Updating the homebrew formula creation script to filter out packages that are needed for pip but not the homebrew formula
* Updating lock file to reflect pre-commit being moved to a dependency
