### PR TITLE
chore: secureli 91 add windows integration pipeline

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -10,6 +10,14 @@ on:
       - feature/**
 
 jobs:
+  test-windows:
+    runs-on: windows-latest
+    steps:
+    - name: setup python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
   test-homebrew-osx:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -22,6 +22,10 @@ jobs:
         pip3 --version #any pip havers?
         pip3 install secureli
         git clone https://github.com/pypa/pip pip
+        cd pip
+        secureli init --yes
+        secureli scan  --mode all-files --yes
+
 
   test-homebrew-osx:
     runs-on: macos-latest

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -17,10 +17,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - name: pip?
+    - name: Install Secureli
       run: |
         pip3 --version #any pip havers?
         pip3 install secureli
+        git clone https://github.com/pypa/pip pip
 
   test-homebrew-osx:
     runs-on: macos-latest

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -17,6 +17,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+    - name: pip?
+      run: pip3 --version #any pip havers?
 
   test-homebrew-osx:
     runs-on: macos-latest

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -19,6 +19,7 @@ jobs:
         python-version: '3.10'
     - name: Install Secureli
       run: |
+        set -x
         pip3 --version #any pip havers?
         pip3 install secureli
         git clone https://github.com/pypa/pip pip

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -18,7 +18,9 @@ jobs:
       with:
         python-version: '3.10'
     - name: pip?
-      run: pip3 --version #any pip havers?
+      run: |
+        pip3 --version #any pip havers?
+        pip3 install secureli
 
   test-homebrew-osx:
     runs-on: macos-latest

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -19,7 +19,6 @@ jobs:
         python-version: '3.10'
     - name: Install Secureli
       run: |
-        set -x
         pip3 --version #any pip havers?
         pip3 install secureli
         git clone https://github.com/pypa/pip pip

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -99,7 +99,7 @@ jobs:
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-linux
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -26,8 +26,9 @@ jobs:
     - name: Run Tests
       run: |
         poetry run poe precommit
+        # Both of these lines error when run on a windows image, more research required as to why
         # poetry run poe coverage
-        poetry run secureli build
+        # poetry run secureli build
 
   build-linux:
     runs-on: ubuntu-latest
@@ -36,12 +37,12 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.ADMIN_TOKEN_SASCHA }}
-    - name: Checkout Secureli Homebrew Repo
-      uses: actions/checkout@v3
-      with:
-        repository: slalombuild/homebrew-secureli
-        token: ${{ secrets.ADMIN_TOKEN_SASCHA }} # `GH_PAT` is a secret that contains your PAT
-        path: homebrew-secureli
+    # - name: Checkout Secureli Homebrew Repo
+    #   uses: actions/checkout@v3
+    #   with:
+    #     repository: slalombuild/homebrew-secureli
+    #     token: ${{ secrets.ADMIN_TOKEN_SASCHA }} # `GH_PAT` is a secret that contains your PAT
+    #     path: homebrew-secureli
     - name: Validate Branch name
       run: ./scripts/get-current-branch.sh
     - name: Set up Python 3.9

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Run Tests
       run: |
         poetry run poe precommit
-        poetry run poe coverage
-        # poetry run secureli build
+        # poetry run poe coverage
+        poetry run secureli build
 
   build-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Run Tests
       run: |
         poetry run poe precommit
-        poetry run poe coverage
-        poetry run secureli build
+        # poetry run poe coverage
+        # poetry run secureli build
 
   build-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run Tests
       run: |
         poetry run poe precommit
-        # poetry run poe coverage
+        poetry run poe coverage
         # poetry run secureli build
 
   build-linux:

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -10,7 +10,26 @@ on:
       - feature/**
 
 jobs:
-  build:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      id: setup-python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+    - name: Set Up Project
+      run: |
+        pip install poetry
+        poetry install
+    - name: Run Tests
+      run: |
+        poetry run poe precommit
+        poetry run poe coverage
+        poetry run secureli build
+
+  build-linux:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -75,7 +75,7 @@ jobs:
     name: Upload release to PyPI
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: build-linux
+    needs: [ build-linux, build-windows ]
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
@@ -96,7 +96,7 @@ jobs:
     name: Upload Homebrew Formula
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: build-linux
+    needs: [ build-linux, build-windows ]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -37,12 +37,6 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.ADMIN_TOKEN_SASCHA }}
-    # - name: Checkout Secureli Homebrew Repo
-    #   uses: actions/checkout@v3
-    #   with:
-    #     repository: slalombuild/homebrew-secureli
-    #     token: ${{ secrets.ADMIN_TOKEN_SASCHA }} # `GH_PAT` is a secret that contains your PAT
-    #     path: homebrew-secureli
     - name: Validate Branch name
       run: ./scripts/get-current-branch.sh
     - name: Set up Python 3.9
@@ -81,6 +75,7 @@ jobs:
     name: Upload release to PyPI
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    needs: build-linux
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -93,6 +93,7 @@ jobs:
 
 
   deploy:
+    name: Upload Homebrew Formula
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build-linux

--- a/Dockerfile_pypi
+++ b/Dockerfile_pypi
@@ -5,11 +5,7 @@ WORKDIR app
 RUN apt-get update && apt-get autoclean && \
     apt-get install -y -q software-properties-common gnupg
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 23F3D4EA75716059
-RUN apt-add-repository https://cli.github.com/packages
-RUN apt-get update
-
-RUN  apt-get install -y -q --allow-unauthenticated gh python3-pip
+RUN  apt-get install -y -q --allow-unauthenticated git python3-pip
 
 RUN pip3 --version && pip3 install secureli
 


### PR DESCRIPTION
Adds a build/test stage for windows into the pipeline.

Cleans up the pipeline, removing an unneeded block that appears to be a duplicate from when we separated out the homebrew deploy.

Removes the need for gh cli from the pypi dockerfile. GH CLI is not required, only git for `clone`. This is in response to troubles on windows with trying to add the gh cli repository key. We don't need it anyway so it's a good change