### PR TITLE
fix: detect-secrets-init-text

### DIFF
--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -223,7 +223,7 @@ class Action(ABC):
 
         if secret_test_id := metadata.security_hook_id:
             self.action_deps.echo.print(
-                f"{config.overall_language} supports secrets detection; running {secret_test_id} on the whole repo"
+                f"{config.overall_language} supports secrets detection; running {secret_test_id}."
             )
             self.action_deps.scanner.scan_repo(
                 ScanMode.ALL_FILES, specific_test=secret_test_id


### PR DESCRIPTION
Fixes Issue when running secureli init on an existing repo.  The log output indicates that the entire repo will be scanned for secrets but the default behavior is to call detect-secrets without the `--all-files` flag so that a baseline is created.

[#90 Running secureli init on existing repo does not appear to run full scan](https://github.com/slalombuild/secureli/issues/90)