### PR TITLE
chore: Clean Up Log Format to accomodate collecting usage stats metric for instrumentation purposes

### DIFF
--- a/secureli/services/logging.py
+++ b/secureli/services/logging.py
@@ -57,6 +57,8 @@ class LogEntry(pydantic.BaseModel):
     action: LogAction
     hook_config: Optional[HookConfiguration]
     failure: Optional[LogFailure] = None
+    total_failure_count: Optional[int]
+    failure_count_details: Optional[object]
 
 
 class LoggingService:
@@ -91,7 +93,13 @@ class LoggingService:
 
         return log_entry
 
-    def failure(self, action: LogAction, details: str) -> LogEntry:
+    def failure(
+        self,
+        action: LogAction,
+        details: str,
+        total_failure_count: Optional[int],
+        individual_failure_count: Optional[object],
+    ) -> LogEntry:
         """
         Capture a failure against an action, with details
         :param action: The action that failed
@@ -109,6 +117,8 @@ class LoggingService:
             failure=LogFailure(
                 details=details,
             ),
+            total_failure_count=total_failure_count,
+            failure_count_details=individual_failure_count,
             hook_config=hook_config,
             primary_language=secureli_config.overall_language,
         )

--- a/secureli/utilities/usage_stats.py
+++ b/secureli/utilities/usage_stats.py
@@ -1,0 +1,17 @@
+from secureli.services.scanner import Failure
+from collections import Counter
+
+
+def convert_failures_to_failure_count(failure_list: list[Failure]):
+    """
+    Convert a list of Failure ids to a list of individual failure count with underscore naming convention
+    :param failure_list: a list of Failure Object
+    """
+    list_of_failure_ids = []
+
+    for failure in failure_list:
+        failure_id_underscore = failure.id.replace("-", "_")
+        list_of_failure_ids.append(failure_id_underscore)
+
+    failure_count_list = Counter(list_of_failure_ids)
+    return failure_count_list

--- a/tests/services/test_logging_service.py
+++ b/tests/services/test_logging_service.py
@@ -77,7 +77,7 @@ def test_that_logging_service_failure_creates_logs_folder_if_not_exists(
         overall_language=None, version_installed=None
     )
 
-    logging_service.failure(LogAction.init, "Horrible Failure")
+    logging_service.failure(LogAction.init, "Horrible Failure", None, None)
 
     mock_path.parent.mkdir.assert_called_once()
 

--- a/tests/utilities/test_usage_stats.py
+++ b/tests/utilities/test_usage_stats.py
@@ -1,0 +1,23 @@
+from secureli.utilities.usage_stats import convert_failures_to_failure_count
+from secureli.services.scanner import Failure
+
+
+def test_that_convert_failures_to_failure_count_returns_correct_count():
+    list_of_failure = [
+        Failure(id="testfailid1", file="testfile1", repo="testrepo1"),
+        Failure(id="testfailid1", file="testfile2", repo="testrepo1"),
+        Failure(id="testfailid2", file="testfile1", repo="testrepo1"),
+    ]
+
+    result = convert_failures_to_failure_count(list_of_failure)
+
+    assert result["testfailid1"] == 2
+    assert result["testfailid2"] == 1
+
+
+def test_that_convert_failures_to_failure_count_returns_correctly_when_no_failure():
+    list_of_failure = []
+
+    result = convert_failures_to_failure_count(list_of_failure)
+
+    assert result == {}


### PR DESCRIPTION
Log format has been modified to

- failure.details change to just a list of failures, instead of the terminal type notation with the color and etc.
- adding total_failure_count
- adding failure_count_details for individual failure count

Log will look more or less like this (removing machine id, and other personal identification in the below sample)
```
{
  "action": "SCAN",
  "failure_count_details.black": 1,
  "failure_count_details.detect_secrets": 2,
  "failure.details": "[{\"repo\": \"https://github.com/Yelp/detect-secrets\", \"id\": \"detect-secrets\", \"file\": \"secureli/services/scanner.py\"}, {\"repo\": \"https://github.com/Yelp/detect-secrets\", \"id\": \"detect-secrets\", \"file\": \"secureli/services/logging.py\"}, {\"repo\": \"https://github.com/psf/black\", \"id\": \"black\", \"file\": \"secureli/utilities/usage_stats.py\"}]",
  "hook_config.repos": "[{\"repo\":\"https://github.com/pre-commit/pre-commit-hooks\",\"revision\":\"v4.3.0\",\"hooks\":[\"check-added-large-files\",\"check-ast\",\"check-docstring-first\",\"check-executables-have-shebangs\",\"check-shebang-scripts-are-executable\",\"check-merge-conflict\",\"check-toml\",\"check-json\",\"check-xml\",\"check-yaml\",\"debug-statements\",\"detect-aws-credentials\",\"detect-private-key\",\"name-tests-test\",\"trailing-whitespace\",\"end-of-file-fixer\",\"check-yaml\"]},{\"repo\":\"https://github.com/pre-commit/pygrep-hooks\",\"revision\":\"v1.9.0\",\"hooks\":[\"python-use-type-annotations\"]},{\"repo\":\"https://github.com/Yelp/detect-secrets\",\"revision\":\"v1.4.0\",\"hooks\":[\"detect-secrets\"]},{\"repo\":\"https://github.com/PyCQA/bandit\",\"revision\":\"1.7.4\",\"hooks\":[\"bandit\"]},{\"repo\":\"https://github.com/psf/black\",\"revision\":\"22.10.0\",\"hooks\":[\"black\"]}]",
  "id": "some identification",
  "machineid": "some machine id",
  "newrelic.source": "api.logs",
  "primary_language": "Python",
  "secureli_version": "0.3.0",
  "status": "FAILURE",
  "timestamp": 1685981882226,
  "total_failure_count": 3,
  "username": "someone@username.com"
}
```

Example log can be queried in backend instrumentation such as new relic for example
![Screenshot 2023-06-05 at 12 41 49 PM](https://github.com/slalombuild/secureli/assets/13907880/46989ca2-72de-4b3f-94b0-f8ca88d8379f)

