### PR TITLE
chore: Add CA Certificates capability to Dockerfiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,14 +44,19 @@ ___Do no setup for this requirement__ unless prompted to do so, and then follow 
 - Install Homebrew if needed: https://brew.sh
 - Install python `brew install python`
 - Install [Poetry](https://python-poetry.org/docs/)
+- Install Docker
+  - This varies by each individual contributor's environment.
+  - Docker Desktop is the simplest
+  - The core seCureLI development team uses [Colima - container runtimes on macOS (and Linux)](https://github.com/abiosoft/colima)
+- Install Docker buildx cli-plugin
+  - This varies by each individual contributor's environment.
+  - Docker Desktop is the simplest
+  - The core seCureLI development team uses homebrew
+    ```shell
+    homebrew install docker-buildx
+    ln -sfn /usr/local/opt/docker-buildx/bin/docker-buildx ~/.docker/cli-plugins/docker-buildx
+    ```
 - Restart your terminal
-  - Similar to the next steps in the homebrew section, follow the instructions to register Poetry with your PATH, running something like the following:
-
-```commandline
-echo '# Add Poetry bin directory to the PATH' >> /Users/tristanl/.zprofile
-echo 'export PATH="/Users/[username]/.local/bin:$PATH"' >> /Users/[username]/.zprofile
-source ~/.zprofile
-```
 - Jump to [Setup (all Operating Systems)](#Setup-all-Operating-Systems)
 
 ## Setup Windows™
@@ -67,6 +72,7 @@ As of June 9, 2023, this repo is being built on and tested against Ubuntu Jammy 
 - Install [Poetry](https://python-poetry.org/docs/)
   - `curl -sSL https://install.python-poetry.org | python3 -`
   - Follow the instructions to add poetry to your shell's $PATH
+- Install [Docker & Docker buildx](https://docs.docker.com/engine/install/)
 
 # Setup (all Operating Systems)
 - Install BATS (Bash Automated Testing System)
@@ -173,6 +179,13 @@ Already installed for Python language and up to date
   - Name: build
   - Parameters: `build`
 - Test each of these configurations and see that the expected “not yet implemented” message is shown
+
+# Building seCureLI Docker Containers behind a corporate proxy
+If you receive SSL/TLS untrusted certificate errors when building the Docker images,
+chances are your organization's digital security team is using a proxy to monitor your encrypted internet usage. To build
+the seCureLI Docker images you will need to inject your organizations self-signed root CA certificate into the images
+at build time. To do this, simply place the root certificate (*.crt format) into the `ca-certificates` directory of this
+repository.  Everything in the ca-certificates directory will be picked up and trusted by the images built.
 
 # SeCureLI Architecture
 

--- a/Dockerfile_homebrew
+++ b/Dockerfile_homebrew
@@ -6,6 +6,11 @@ RUN apt-get update && apt-get autoclean && \
     apt-get install -y -q --allow-unauthenticated \
     git curl sudo build-essential
 
+# Install ca-certificates
+RUN apt-get install -y ca-certificates
+COPY ./ca-certificates* /app/ca-certificates
+RUN cp /app/ca-certificates/*.crt /usr/local/share/ca-certificates | true && update-ca-certificates
+
 # set up dirs
 RUN useradd -m -s /bin/bash linuxbrew && \
     usermod -aG sudo linuxbrew &&  \

--- a/Dockerfile_pypi
+++ b/Dockerfile_pypi
@@ -5,9 +5,14 @@ WORKDIR app
 RUN apt-get update && apt-get autoclean && \
     apt-get install -y -q software-properties-common gnupg
 
+# Install ca-certificates
+RUN apt-get install -y ca-certificates
+COPY ./ca-certificates* /app/ca-certificates
+RUN cp /app/ca-certificates/*.crt /usr/local/share/ca-certificates | true && update-ca-certificates
+
 RUN  apt-get install -y -q --allow-unauthenticated git python3-pip
 
-RUN pip3 --version && pip3 install secureli
+RUN pip3 --version && pip3 install secureli --break-system-packages
 
 RUN git clone https://github.com/pypa/pip pip
 WORKDIR pip

--- a/Dockerfile_secureli
+++ b/Dockerfile_secureli
@@ -4,6 +4,7 @@
 FROM python:3.9
 WORKDIR /app
 COPY . /app
+RUN cp /app/ca-certificates/*.crt /usr/local/share/ca-certificates | true && update-ca-certificates
 RUN pip install poetry
 RUN poetry install
 RUN poetry run poe precommit

--- a/ca-certificates/.gitignore
+++ b/ca-certificates/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This PR allows a contributor to put a Trusted Root Certificate Authority in the ca-certificates directory of this repo in order to allow access through a corporate proxy that sniffs SSL/TLS traffic.