### PR TITLE
chore: secureli-59 adding support to Go

### DIFF
--- a/secureli/resources/files/go-pre-commit.yaml
+++ b/secureli/resources/files/go-pre-commit.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-json
+      - id: check-xml
+      - id: check-yaml
+      - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
+      - id: detect-private-key
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.53.3
+    hooks:
+      - id: golangci-lint

--- a/secureli/services/language_support.py
+++ b/secureli/services/language_support.py
@@ -5,7 +5,7 @@ import pydantic
 from secureli.abstractions.pre_commit import PreCommitAbstraction
 from secureli.services.git_ignore import GitIgnoreService
 
-supported_languages = ["C#", "Python", "Java", "Terraform", "TypeScript"]
+supported_languages = ["C#", "Python", "Java", "Terraform", "TypeScript", "Go"]
 
 
 class LanguageMetadata(pydantic.BaseModel):

--- a/tests/actions/test_scan_action.py
+++ b/tests/actions/test_scan_action.py
@@ -1,6 +1,8 @@
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest import mock
+from unittest.mock import MagicMock, patch
 
+import os
 import pytest
 
 from secureli.actions.action import ActionDependencies
@@ -133,6 +135,7 @@ def scan_action(
     )
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_errors_if_not_successful(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -147,6 +150,7 @@ def test_that_scan_repo_errors_if_not_successful(
     mock_echo.print.assert_called_with("Bad Error")
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_scans_if_installed(
     scan_action: ScanAction,
     mock_secureli_config: MagicMock,
@@ -164,6 +168,7 @@ def test_that_scan_repo_scans_if_installed(
     mock_scanner.scan_repo.assert_called_once()
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_continue_scan_if_upgrade_canceled(
     scan_action: ScanAction,
     mock_secureli_config: MagicMock,
@@ -182,6 +187,7 @@ def test_that_scan_repo_continue_scan_if_upgrade_canceled(
     mock_scanner.scan_repo.assert_called_once()
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_does_not_scan_if_not_installed(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -196,6 +202,7 @@ def test_that_scan_repo_does_not_scan_if_not_installed(
     mock_scanner.scan_repo.assert_not_called()
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_handles_declining_to_add_ignore_for_failures(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -218,6 +225,7 @@ def test_that_scan_repo_handles_declining_to_add_ignore_for_failures(
     mock_settings_repository.save.assert_not_called()
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_adds_ignore_for_all_files_when_prompted(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -243,6 +251,7 @@ def test_that_scan_repo_adds_ignore_for_all_files_when_prompted(
     assert saved_suppressed_id is expected_suppressed_id
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_adds_ignore_for_all_files_when_settings_exist_when_prompted(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -268,6 +277,7 @@ def test_that_scan_repo_adds_ignore_for_all_files_when_settings_exist_when_promp
     assert saved_suppressed_id is expected_suppressed_id
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_skips_ignore_for_all_files_when_ignore_already_exists(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -293,6 +303,7 @@ def test_that_scan_repo_skips_ignore_for_all_files_when_ignore_already_exists(
     assert saved_suppressed_id is expected_suppressed_id
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_adds_ignore_for_one_file_when_prompted(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -320,6 +331,7 @@ def test_that_scan_repo_adds_ignore_for_one_file_when_prompted(
     assert saved_excluded_file is expected_excluded_file
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_adds_ignore_for_one_file_when_settings_exist_when_prompted(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -347,6 +359,7 @@ def test_that_scan_repo_adds_ignore_for_one_file_when_settings_exist_when_prompt
     assert saved_excluded_file is expected_excluded_file
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_skips_ignore_for_one_file_when_ignore_already_present(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -374,6 +387,7 @@ def test_that_scan_repo_skips_ignore_for_one_file_when_ignore_already_present(
     assert saved_excluded_file is expected_excluded_file
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_handles_missing_repo_while_adding_ignore_rule(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -399,6 +413,7 @@ def test_that_scan_repo_handles_missing_repo_while_adding_ignore_rule(
     )
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_does_not_add_ignore_if_both_ignore_types_declined(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -422,6 +437,7 @@ def test_that_scan_repo_does_not_add_ignore_if_both_ignore_types_declined(
     assert saved_settings is mock_settings_repository.load.return_value
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_does_not_add_ignore_if_all_failures_declined(
     scan_action: ScanAction,
     mock_scanner: MagicMock,
@@ -445,6 +461,7 @@ def test_that_scan_repo_does_not_add_ignore_if_all_failures_declined(
     assert saved_settings is mock_settings_repository.load.return_value
 
 
+@mock.patch.dict(os.environ, {"API_KEY": "", "API_ENDPOINT": ""}, clear=True)
 def test_that_scan_repo_does_not_add_ignore_if_always_yes_is_true(
     scan_action: ScanAction,
     mock_scanner: MagicMock,


### PR DESCRIPTION
Adding linter for Go Language, as well as pre commit hook and detect secret
Also fix unit tests due to environment variable issue.

Screenshot is showing golangci-lint caught an issue during secureli scanning
<img width="895" alt="Screenshot 2023-06-19 at 9 42 33 AM" src="https://github.com/slalombuild/secureli/assets/13907880/82d99ce0-d503-4f5a-bda6-9a041de8d2fe">
