### PR TITLE
feat: adding optional directory command for init, scan, and update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,11 +23,11 @@ repos:
   - id: end-of-file-fixer
   - id: check-yaml
   repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.3.0
 - hooks:
   - id: python-use-type-annotations
   repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.10.0
+  rev: v1.9.0
 - hooks:
   - id: detect-secrets
   repo: https://github.com/Yelp/detect-secrets
@@ -40,8 +40,8 @@ repos:
     - medium
     id: bandit
   repo: https://github.com/PyCQA/bandit
-  rev: 1.7.5
+  rev: 1.7.4
 - hooks:
   - id: black
   repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 22.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,11 +23,11 @@ repos:
   - id: end-of-file-fixer
   - id: check-yaml
   repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
 - hooks:
   - id: python-use-type-annotations
   repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.9.0
+  rev: v1.10.0
 - hooks:
   - id: detect-secrets
   repo: https://github.com/Yelp/detect-secrets
@@ -40,8 +40,8 @@ repos:
     - medium
     id: bandit
   repo: https://github.com/PyCQA/bandit
-  rev: 1.7.4
+  rev: 1.7.5
 - hooks:
   - id: black
   repo: https://github.com/psf/black
-  rev: 22.10.0
+  rev: 23.3.0

--- a/secureli/abstractions/pre_commit.py
+++ b/secureli/abstractions/pre_commit.py
@@ -196,7 +196,7 @@ class PreCommitAbstraction:
         :raises LanguageNotSupportedError if a pre-commit template cannot be found for the specified language
         :raises InstallFailedError if the template was found, but an error occurred installing it
         """
-        path_to_pre_commit_file = folder_path / ".pre-commit-config.yaml"
+        path_to_pre_commit_file = Path(folder_path / ".pre-commit-config.yaml")
 
         # Raises a LanguageNotSupportedError if language doesn't resolve to a yaml file
         language_config = self._get_language_config(language)

--- a/secureli/abstractions/pre_commit.py
+++ b/secureli/abstractions/pre_commit.py
@@ -189,15 +189,14 @@ class PreCommitAbstraction:
 
         return None
 
-    def install(self, language: str) -> InstallResult:
+    def install(self, folder_path: Path, language: str) -> InstallResult:
         """
         Identifies the template we hold for the specified language, writes it, installs it, and cleans up
         :param language: The language to identify a template for
         :raises LanguageNotSupportedError if a pre-commit template cannot be found for the specified language
         :raises InstallFailedError if the template was found, but an error occurred installing it
         """
-
-        path_to_pre_commit_file = Path(".pre-commit-config.yaml")
+        path_to_pre_commit_file = folder_path / ".pre-commit-config.yaml"
 
         # Raises a LanguageNotSupportedError if language doesn't resolve to a yaml file
         language_config = self._get_language_config(language)
@@ -205,13 +204,13 @@ class PreCommitAbstraction:
         with open(path_to_pre_commit_file, "w") as f:
             f.write(language_config.config_data)
 
-        completed_process = subprocess.run(["pre-commit", "install"])
+        completed_process = subprocess.run(["pre-commit", "install"], cwd=folder_path)
         if completed_process.returncode != 0:
             raise InstallFailedError(
                 f"Installing the pre-commit script for {language} failed"
             )
 
-        install_configs_result = self._install_pre_commit_configs(language)
+        install_configs_result = self._install_pre_commit_configs(folder_path, language)
 
         return InstallResult(
             successful=True,
@@ -327,6 +326,7 @@ class PreCommitAbstraction:
 
     def autoupdate_hooks(
         self,
+        folder_path: Path,
         bleeding_edge: bool = False,
         freeze: bool = False,
         repos: Optional[list] = None,
@@ -334,6 +334,7 @@ class PreCommitAbstraction:
         """
         Updates the precommit hooks but executing precommit's autoupdate command.  Additional info at
         https://pre-commit.com/#pre-commit-autoupdate
+        :param folder path: specified full path directory (default to current directory)
         :param bleeding edge: True if updating to the bleeding edge of the default branch instead of
         the latest tagged version (which is the default behavior)
         :param freeze: Set to True to store "frozen" hashes in rev instead of tag names.
@@ -367,7 +368,9 @@ class PreCommitAbstraction:
 
             subprocess_args.extend(repo_args)
 
-        completed_process = subprocess.run(subprocess_args, stdout=subprocess.PIPE)
+        completed_process = subprocess.run(
+            subprocess_args, cwd=folder_path, stdout=subprocess.PIPE
+        )
         output = (
             completed_process.stdout.decode("utf8") if completed_process.stdout else ""
         )
@@ -376,14 +379,16 @@ class PreCommitAbstraction:
         else:
             return ExecuteResult(successful=True, output=output)
 
-    def update(self) -> ExecuteResult:
+    def update(self, folder_path: Path) -> ExecuteResult:
         """
         Installs the hooks defined in pre-commit-config.yml.
         :return: ExecuteResult, indicating success or failure.
         """
         subprocess_args = ["pre-commit", "install-hooks", "--color", "always"]
 
-        completed_process = subprocess.run(subprocess_args, stdout=subprocess.PIPE)
+        completed_process = subprocess.run(
+            subprocess_args, cwd=folder_path, stdout=subprocess.PIPE
+        )
         output = (
             completed_process.stdout.decode("utf8") if completed_process.stdout else ""
         )
@@ -392,7 +397,7 @@ class PreCommitAbstraction:
         else:
             return ExecuteResult(successful=True, output=output)
 
-    def remove_unused_hooks(self) -> ExecuteResult:
+    def remove_unused_hooks(self, folder_path: Path) -> ExecuteResult:
         """
         Removes unused hook repos from the cache.  Pre-commit determines which flags are "unused" by comparing
         the repos to the pre-commit-config.yaml file.  Any cached hook repos that are not in the config file
@@ -401,7 +406,9 @@ class PreCommitAbstraction:
         """
         subprocess_args = ["pre-commit", "gc", "--color", "always"]
 
-        completed_process = subprocess.run(subprocess_args, stdout=subprocess.PIPE)
+        completed_process = subprocess.run(
+            subprocess_args, cwd=folder_path, stdout=subprocess.PIPE
+        )
         output = (
             completed_process.stdout.decode("utf8") if completed_process.stdout else ""
         )
@@ -819,7 +826,7 @@ class PreCommitAbstraction:
         return LoadLanguageConfigsResult(success=False, config_data=list())
 
     def _install_pre_commit_configs(
-        self, language: str
+        self, folder_path: Path, language: str
     ) -> LanguagePreCommitConfigInstallResult:
         """
         Install any config files for given language to support any pre-commit commands.
@@ -841,13 +848,13 @@ class PreCommitAbstraction:
                 try:
                     for key in config:
                         config_name = f"{slugify(language)}.{key}.yaml"
-                        path_to_config_file = Path(f".secureli/{config_name}")
+                        path_to_config_file = folder_path / f".secureli/{config_name}"
 
                         with open(path_to_config_file, "w") as f:
                             f.write(yaml.dump(config[key]))
 
                         completed_process = subprocess.run(
-                            ["pre-commit", "install-language-config"]
+                            ["pre-commit", "install-language-config"], cwd=folder_path
                         )
 
                         if completed_process.returncode != 0:

--- a/secureli/actions/build.py
+++ b/secureli/actions/build.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from secureli.abstractions.echo import EchoAbstraction, Color
 from secureli.services.logging import LoggingService, LogAction
 
@@ -20,4 +21,4 @@ class BuildAction:
         """
         self.echo.print(self.build_data, color=color, bold=True)
 
-        self.logging.success(LogAction.build)
+        self.logging.success(Path("."), LogAction.build)

--- a/secureli/actions/initializer.py
+++ b/secureli/actions/initializer.py
@@ -25,6 +25,6 @@ class InitializerAction(Action):
         """
         verify_result = self.verify_install(folder_path, reset, always_yes)
         if verify_result.outcome in ScanAction.halting_outcomes:
-            self.logging.failure(LogAction.init, verify_result.outcome)
+            self.logging.failure(folder_path, LogAction.init, verify_result.outcome)
         else:
-            self.logging.success(LogAction.init)
+            self.logging.success(folder_path, LogAction.init)

--- a/secureli/actions/scan.py
+++ b/secureli/actions/scan.py
@@ -95,7 +95,7 @@ class ScanAction(Action):
             post_log(log_data.json(exclude_none=True))
         else:
             self.echo.print("Scan executed successfully and detected no issues!")
-            log_data = self.logging.success(LogAction.scan)
+            log_data = self.logging.success(folder_path, LogAction.scan)
 
             post_log(log_data.json(exclude_none=True))
 

--- a/secureli/actions/scan.py
+++ b/secureli/actions/scan.py
@@ -85,6 +85,7 @@ class ScanAction(Action):
 
         if not scan_result.successful:
             log_data = self.logging.failure(
+                folder_path,
                 LogAction.scan,
                 scan_result_failures_json_string,
                 failure_count,

--- a/secureli/actions/update.py
+++ b/secureli/actions/update.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from pathlib import Path
 from secureli.abstractions.echo import EchoAbstraction
 from secureli.services.logging import LoggingService, LogAction
 from secureli.services.updater import UpdaterService
@@ -19,7 +20,7 @@ class UpdateAction(Action):
         self.logging = logging
         self.updater = updater
 
-    def update_hooks(self, latest: Optional[bool] = False):
+    def update_hooks(self, folder_path: Path, latest: Optional[bool] = False):
         """
         Installs the hooks defined in pre-commit-config.yml.
         :param latest: Indicates whether you want to update to the latest versions
@@ -28,7 +29,7 @@ class UpdateAction(Action):
         """
         if latest:
             self.echo.print("Updating hooks to the latest version...")
-            update_result = self.updater.update_hooks()
+            update_result = self.updater.update_hooks(folder_path)
             details = (
                 update_result.output
                 or "Unknown output while updating hooks to latest version"
@@ -36,18 +37,18 @@ class UpdateAction(Action):
             self.echo.print(details)
             if not update_result.successful:
                 self.echo.print(details)
-                self.logging.failure(LogAction.update, details)
+                self.logging.failure(folder_path, LogAction.update, details)
             else:
                 self.echo.print("Hooks successfully updated to latest version")
-                self.logging.success(LogAction.update)
+                self.logging.success(folder_path, LogAction.update)
         else:
             self.echo.print("Beginning update...")
-            install_result = self.updater.update()
+            install_result = self.updater.update(folder_path)
             details = install_result.output or "Unknown output during hook installation"
             self.echo.print(details)
             if not install_result.successful:
                 self.echo.print(details)
-                self.logging.failure(LogAction.update, details)
+                self.logging.failure(folder_path, LogAction.update, details)
             else:
                 self.echo.print("Update executed successfully.")
-                self.logging.success(LogAction.update)
+                self.logging.success(folder_path, LogAction.update)

--- a/secureli/main.py
+++ b/secureli/main.py
@@ -48,6 +48,12 @@ def init(
         "-y",
         help="Say 'yes' to every prompt automatically without input",
     ),
+    directory: Optional[str] = Option(
+        ".",
+        "--directory",
+        "-d",
+        help="Run seCureLI on specified full path directory (default to current directory)",
+    ),
 ):
     """
     Detect languages and initialize pre-commit hooks and linters for the project
@@ -75,11 +81,17 @@ def scan(
         "-t",
         help="Limit the scan to a specific hook ID from your pre-commit config",
     ),
+    directory: Optional[str] = Option(
+        ".",
+        "--directory",
+        "-d",
+        help="Run seCureLI on specified full path directory (default to current directory)",
+    ),
 ):
     """
     Performs an explicit check of the repository to detect security issues without remote logging.
     """
-    container.scan_action().scan_repo(Path("."), mode, yes, specific_test)
+    container.scan_action().scan_repo(Path(directory), mode, yes, specific_test)
 
 
 @app.command(hidden=True)

--- a/secureli/main.py
+++ b/secureli/main.py
@@ -109,12 +109,18 @@ def update(
         "--latest",
         "-l",
         help="Update the installed pre-commit hooks to their latest versions",
-    )
+    ),
+    directory: Optional[str] = Option(
+        ".",
+        "--directory",
+        "-d",
+        help="Run seCureLI on specified full path directory (default to current directory)",
+    ),
 ):
     """
     Update linters, configuration, and all else needed to maintain a secure repository.
     """
-    container.update_action().update_hooks(latest)
+    container.update_action().update_hooks(Path(directory), latest)
 
 
 if __name__ == "__main__":

--- a/secureli/main.py
+++ b/secureli/main.py
@@ -58,7 +58,7 @@ def init(
     """
     Detect languages and initialize pre-commit hooks and linters for the project
     """
-    container.initializer_action().initialize_repo(Path("."), reset, yes)
+    container.initializer_action().initialize_repo(Path(directory), reset, yes)
 
 
 @app.command()

--- a/secureli/repositories/secureli_config.py
+++ b/secureli/repositories/secureli_config.py
@@ -30,8 +30,7 @@ class SecureliConfigRepository:
         """
         secureli_folder_path = self._initialize_secureli_directory(folder_path)
         secureli_config_path = Path(secureli_folder_path / "repo-config.yaml")
-        print("***************")
-        print(secureli_config_path)
+
         if not secureli_config_path.exists():
             print("NOT EXISTS")
             return SecureliConfig()
@@ -47,7 +46,6 @@ class SecureliConfigRepository:
         :return: The folder path of the .secureli folder that either exists or was just created.
         """
         secureli_folder_path = Path(folder_path / ".secureli")
-        print("$$$$$$$$$")
-        print(secureli_folder_path)
+
         secureli_folder_path.mkdir(parents=True, exist_ok=True)
         return secureli_folder_path

--- a/secureli/repositories/secureli_config.py
+++ b/secureli/repositories/secureli_config.py
@@ -32,11 +32,9 @@ class SecureliConfigRepository:
         secureli_config_path = Path(secureli_folder_path / "repo-config.yaml")
 
         if not secureli_config_path.exists():
-            print("NOT EXISTS")
             return SecureliConfig()
 
         with open(secureli_config_path, "r") as f:
-            print("EXISTS")
             data = yaml.safe_load(f)
             return SecureliConfig.parse_obj(data)
 

--- a/secureli/repositories/secureli_config.py
+++ b/secureli/repositories/secureli_config.py
@@ -29,11 +29,15 @@ class SecureliConfigRepository:
         configuration object, capable of being modified and saved via the `save` method
         """
         secureli_folder_path = self._initialize_secureli_directory(folder_path)
-        secureli_config_path = secureli_folder_path / "repo-config.yaml"
+        secureli_config_path = Path(secureli_folder_path / "repo-config.yaml")
+        print("***************")
+        print(secureli_config_path)
         if not secureli_config_path.exists():
+            print("NOT EXISTS")
             return SecureliConfig()
 
         with open(secureli_config_path, "r") as f:
+            print("EXISTS")
             data = yaml.safe_load(f)
             return SecureliConfig.parse_obj(data)
 
@@ -42,6 +46,8 @@ class SecureliConfigRepository:
         Creates the .secureli folder within the current directory if needed.
         :return: The folder path of the .secureli folder that either exists or was just created.
         """
-        secureli_folder_path = folder_path / ".secureli"
+        secureli_folder_path = Path(folder_path / ".secureli")
+        print("$$$$$$$$$")
+        print(secureli_folder_path)
         secureli_folder_path.mkdir(parents=True, exist_ok=True)
         return secureli_folder_path

--- a/secureli/repositories/secureli_config.py
+++ b/secureli/repositories/secureli_config.py
@@ -13,22 +13,22 @@ class SecureliConfig(BaseModel):
 class SecureliConfigRepository:
     """Save and retrieve the SeCureLI configuration"""
 
-    def save(self, secureli_config: SecureliConfig):
+    def save(self, folder_path: Path, secureli_config: SecureliConfig):
         """
         Save the specified configuration to the .secureli folder
         :param secureli_config: The populated configuration to save
         """
-        secureli_folder_path = self._initialize_secureli_directory()
+        secureli_folder_path = self._initialize_secureli_directory(folder_path)
         secureli_config_path = secureli_folder_path / "repo-config.yaml"
         with open(secureli_config_path, "w") as f:
             yaml.dump(secureli_config.dict(), f)
 
-    def load(self) -> SecureliConfig:
+    def load(self, folder_path: Path) -> SecureliConfig:
         """
         Load the SeCureLI config from the expected configuration file path or return a new
         configuration object, capable of being modified and saved via the `save` method
         """
-        secureli_folder_path = self._initialize_secureli_directory()
+        secureli_folder_path = self._initialize_secureli_directory(folder_path)
         secureli_config_path = secureli_folder_path / "repo-config.yaml"
         if not secureli_config_path.exists():
             return SecureliConfig()
@@ -37,11 +37,11 @@ class SecureliConfigRepository:
             data = yaml.safe_load(f)
             return SecureliConfig.parse_obj(data)
 
-    def _initialize_secureli_directory(self):
+    def _initialize_secureli_directory(self, folder_path: Path):
         """
         Creates the .secureli folder within the current directory if needed.
         :return: The folder path of the .secureli folder that either exists or was just created.
         """
-        secureli_folder_path = Path(".") / ".secureli"
+        secureli_folder_path = folder_path / ".secureli"
         secureli_folder_path.mkdir(parents=True, exist_ok=True)
         return secureli_folder_path

--- a/secureli/services/language_support.py
+++ b/secureli/services/language_support.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import pydantic
 
+from pathlib import Path
 from secureli.abstractions.pre_commit import PreCommitAbstraction
 from secureli.services.git_ignore import GitIgnoreService
 
@@ -45,7 +46,7 @@ class LanguageSupportService:
         # For now, just a passthrough to pre-commit hook abstraction
         return self.pre_commit_hook.version_for_language(language)
 
-    def apply_support(self, language: str) -> LanguageMetadata:
+    def apply_support(self, folder_path: Path, language: str) -> LanguageMetadata:
         """
         Applies Secure Build support for the provided language
         :param language: The language to provide support for
@@ -55,7 +56,7 @@ class LanguageSupportService:
         """
 
         # Start by identifying and installing the appropriate pre-commit template (if we have one)
-        install_result = self.pre_commit_hook.install(language)
+        install_result = self.pre_commit_hook.install(folder_path, language)
 
         # Add .secureli/ to the gitignore folder if needed
         self.git_ignore.ignore_secureli_files()

--- a/secureli/services/logging.py
+++ b/secureli/services/logging.py
@@ -18,9 +18,6 @@ def generate_unique_id(folder_path: Path) -> str:
     A unique identifier representing the log entry, including various
     bits specific to the user and environment
     """
-    print("$$$$$$$$$$$$$")
-    print(current_branch_name(folder_path))
-    print("$$$$$$$$$$$$$")
     origin_email_branch = f"{origin_url(folder_path)}|{git_user_email()}|{current_branch_name(folder_path)}"
     return f"{uuid4()}|{origin_email_branch}"
 
@@ -95,6 +92,7 @@ class LoggingService:
         )
         print("***************")
         print(log_entry)
+        print("***************")
         self._log(folder_path, log_entry)
 
         return log_entry
@@ -136,9 +134,8 @@ class LoggingService:
 
     def _log(self, folder_path: Path, log_entry: LogEntry):
         """Commit a log entry to the branch log file"""
-        log_folder_path = folder_path / ".secureli/logs"
+        log_folder_path = Path(folder_path / ".secureli/logs")
         path_to_log = log_folder_path / f"{current_branch_name(folder_path)}"
-        print(path_to_log)
 
         # Do not simply mkdir the log folder path, in case the branch name contains
         # additional folder structure, like `bugfix/` or `feature/`

--- a/secureli/services/logging.py
+++ b/secureli/services/logging.py
@@ -90,9 +90,7 @@ class LoggingService:
             hook_config=hook_config,
             primary_language=secureli_config.overall_language,
         )
-        print("***************")
-        print(log_entry)
-        print("***************")
+
         self._log(folder_path, log_entry)
 
         return log_entry

--- a/secureli/services/logging.py
+++ b/secureli/services/logging.py
@@ -72,12 +72,12 @@ class LoggingService:
         self.pre_commit = pre_commit
         self.secureli_config = secureli_config
 
-    def success(self, action: LogAction) -> LogEntry:
+    def success(self, folder_path: Path, action: LogAction) -> LogEntry:
         """
         Capture that a successful conclusion has been reached for an action
         :param action: The action that succeeded
         """
-        secureli_config = self.secureli_config.load()
+        secureli_config = self.secureli_config.load(folder_path=folder_path)
         hook_config = (
             self.pre_commit.get_configuration(secureli_config.overall_language)
             if secureli_config.overall_language
@@ -89,12 +89,13 @@ class LoggingService:
             hook_config=hook_config,
             primary_language=secureli_config.overall_language,
         )
-        self._log(log_entry)
+        self._log(folder_path, log_entry)
 
         return log_entry
 
     def failure(
         self,
+        folder_path: Path,
         action: LogAction,
         details: str,
         total_failure_count: Optional[int],
@@ -105,7 +106,7 @@ class LoggingService:
         :param action: The action that failed
         :param details: Details about the failure
         """
-        secureli_config = self.secureli_config.load()
+        secureli_config = self.secureli_config.load(folder_path=folder_path)
         hook_config = (
             None
             if not secureli_config.overall_language
@@ -122,13 +123,13 @@ class LoggingService:
             hook_config=hook_config,
             primary_language=secureli_config.overall_language,
         )
-        self._log(log_entry)
+        self._log(folder_path, log_entry)
 
         return log_entry
 
-    def _log(self, log_entry: LogEntry):
+    def _log(self, folder_path: Path, log_entry: LogEntry):
         """Commit a log entry to the branch log file"""
-        log_folder_path = Path(f".secureli/logs")
+        log_folder_path = folder_path / ".secureli/logs"
         path_to_log = log_folder_path / f"{current_branch_name()}"
 
         # Do not simply mkdir the log folder path, in case the branch name contains

--- a/secureli/utilities/git_meta.py
+++ b/secureli/utilities/git_meta.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import subprocess
 import configparser
 
@@ -10,10 +12,10 @@ def git_user_email() -> str:
     return output
 
 
-def origin_url() -> str:
+def origin_url(folder_path: Path) -> str:
     """Leverage the git config file to determine the remote origin URL"""
     git_config_parser = configparser.ConfigParser()
-    git_config_parser.read(".git/config")
+    git_config_parser.read(f"{folder_path}/.git/config")
     return (
         git_config_parser['remote "origin"'].get("url", "UNKNOWN")
         if git_config_parser.has_section('remote "origin"')
@@ -21,10 +23,10 @@ def origin_url() -> str:
     )
 
 
-def current_branch_name() -> str:
+def current_branch_name(folder_path: Path) -> str:
     """Leverage the git HEAD file to determine the current branch name"""
     try:
-        with open(".git/HEAD", "r") as f:
+        with open(f"{folder_path}/.git/HEAD", "r") as f:
             content = f.readlines()
             for line in content:
                 if line[0:4] == "ref:":

--- a/tests/actions/test_action.py
+++ b/tests/actions/test_action.py
@@ -11,7 +11,7 @@ from secureli.services.language_support import LanguageMetadata
 from secureli.services.updater import UpdateResult
 from secureli.abstractions.pre_commit import ValidateConfigResult
 
-test_folder_path = Path("does-not-matter")
+test_folder_path = Path(".")
 
 
 @pytest.fixture()
@@ -280,7 +280,7 @@ def test_that_update_secureli_handles_declined_update(
     mock_echo: MagicMock,
 ):
     mock_echo.confirm.return_value = False
-    update_result = action._update_secureli(always_yes=False)
+    update_result = action._update_secureli(test_folder_path, always_yes=False)
 
     assert update_result.outcome == "update-canceled"
 
@@ -292,6 +292,6 @@ def test_that_update_secureli_handles_failed_update(
     mock_updater.update.return_value = UpdateResult(
         successful=False, outcome="update failed"
     )
-    update_result = action._update_secureli(always_yes=False)
+    update_result = action._update_secureli(test_folder_path, always_yes=False)
 
     assert update_result.outcome == "update-failed"

--- a/tests/actions/test_initializer_action.py
+++ b/tests/actions/test_initializer_action.py
@@ -65,7 +65,9 @@ def test_that_initialize_repo_does_not_load_config_when_resetting(
 
     mock_secureli_config.load.assert_not_called()
 
-    mock_logging_service.success.assert_called_once_with(LogAction.init)
+    mock_logging_service.success.assert_called_once_with(
+        test_folder_path, LogAction.init
+    )
 
 
 def test_that_initialize_repo_logs_failure_when_failing_to_verify(
@@ -78,4 +80,6 @@ def test_that_initialize_repo_logs_failure_when_failing_to_verify(
 
     initializer_action.initialize_repo(test_folder_path, True, True)
 
-    mock_logging_service.failure.assert_called_once_with(LogAction.init, ANY)
+    mock_logging_service.failure.assert_called_once_with(
+        test_folder_path, LogAction.init, ANY
+    )

--- a/tests/actions/test_update_action.py
+++ b/tests/actions/test_update_action.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -5,6 +6,8 @@ import pytest
 from secureli.actions.action import ActionDependencies
 from secureli.actions.update import UpdateAction
 from secureli.services.updater import UpdateResult
+
+test_folder_path = Path(".")
 
 
 @pytest.fixture()
@@ -65,7 +68,7 @@ def test_that_update_action_executes_successfully(
         successful=True, output="Some update performed"
     )
 
-    update_action.update_hooks()
+    update_action.update_hooks(test_folder_path)
 
     mock_echo.print.assert_called_with("Update executed successfully.")
 
@@ -79,7 +82,7 @@ def test_that_update_action_handles_failed_execution(
         successful=False, output="Failed to update"
     )
 
-    update_action.update_hooks()
+    update_action.update_hooks(test_folder_path)
 
     mock_echo.print.assert_called_with("Failed to update")
 
@@ -88,7 +91,7 @@ def test_that_latest_flag_initiates_update(
     update_action: UpdateAction,
     mock_echo: MagicMock,
 ):
-    update_action.update_hooks(latest=True)
+    update_action.update_hooks(test_folder_path, latest=True)
 
     mock_echo.print.assert_called_with("Hooks successfully updated to latest version")
 
@@ -101,6 +104,6 @@ def test_that_latest_flag_handles_failed_update(
     mock_updater.update_hooks.return_value = UpdateResult(
         successful=False, output="Update failed"
     )
-    update_action.update_hooks(latest=True)
+    update_action.update_hooks(test_folder_path, latest=True)
 
     mock_echo.print.assert_called_with("Update failed")

--- a/tests/application/test_main.py
+++ b/tests/application/test_main.py
@@ -21,7 +21,7 @@ def test_that_setup_wires_up_container(mock_container: MagicMock):
 
 
 def test_that_init_creates_initializer_action_and_executes(mock_container: MagicMock):
-    secureli.main.init()
+    secureli.main.init(directory=".")
 
     mock_container.initializer_action.assert_called_once()
 
@@ -33,7 +33,7 @@ def test_that_build_creates_build_action_and_executes(mock_container: MagicMock)
 
 
 def test_that_scan_is_tbd(mock_container: MagicMock):
-    secureli.main.scan()
+    secureli.main.scan(directory=".")
 
     mock_container.scan_action.assert_called_once()
 

--- a/tests/application/test_main.py
+++ b/tests/application/test_main.py
@@ -39,6 +39,6 @@ def test_that_scan_is_tbd(mock_container: MagicMock):
 
 
 def test_that_update_is_tbd(mock_container: MagicMock):
-    secureli.main.update()
+    secureli.main.update(directory=".")
 
     mock_container.update_action.assert_called_once()

--- a/tests/repositories/test_secureli_config.py
+++ b/tests/repositories/test_secureli_config.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,6 +8,8 @@ from secureli.repositories.secureli_config import (
     SecureliConfigRepository,
     SecureliConfig,
 )
+
+test_folder_path = Path(".")
 
 
 @pytest.fixture()
@@ -65,7 +68,7 @@ def test_that_repo_synthesizes_default_config_when_missing(
     non_existent_path: MagicMock,
     secureli_config: SecureliConfigRepository,
 ):
-    config = secureli_config.load()
+    config = secureli_config.load(test_folder_path)
 
     assert config.overall_language is None
 
@@ -74,7 +77,7 @@ def test_that_repo_loads_config_when_present(
     existent_path: MagicMock,
     secureli_config: SecureliConfigRepository,
 ):
-    config = secureli_config.load()
+    config = secureli_config.load(test_folder_path)
 
     assert config.overall_language == "RadLang"
 
@@ -85,6 +88,6 @@ def test_that_repo_saves_config(
     secureli_config: SecureliConfigRepository,
 ):
     config = SecureliConfig(overall_language="AwesomeLang")
-    secureli_config.save(config)
+    secureli_config.save(test_folder_path, config)
 
     mock_open.assert_called_once()

--- a/tests/repositories/test_secureli_config.py
+++ b/tests/repositories/test_secureli_config.py
@@ -18,9 +18,13 @@ def non_existent_path(mocker: MockerFixture) -> MagicMock:
     config_file_path.exists.return_value = False
     config_file_path.is_dir.return_value = False
     mock_folder_path = MagicMock()
+    mock_folder_path.exists.return_value = False
+    mock_folder_path.is_dir.return_value = False
     mock_folder_path.__truediv__.return_value = config_file_path
 
     mock_secureli_folder_path = MagicMock()
+    mock_secureli_folder_path.exists.return_value = False
+    mock_secureli_folder_path.is_dir.return_value = False
     mock_secureli_folder_path.__truediv__.return_value = mock_folder_path
 
     mock_path_class = MagicMock()

--- a/tests/services/test_language_support.py
+++ b/tests/services/test_language_support.py
@@ -52,7 +52,7 @@ def test_that_language_support_attempts_to_install_pre_commit_hooks(
 ):
     metadata = language_support_service.apply_support(test_folder_path, "RadLang")
 
-    mock_pre_commit_hook.install.assert_called_once_with("RadLang")
+    mock_pre_commit_hook.install.assert_called_once_with(test_folder_path, "RadLang")
     assert metadata.security_hook_id == "baddie-finder"
 
 

--- a/tests/services/test_language_support.py
+++ b/tests/services/test_language_support.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,6 +8,8 @@ from secureli.abstractions.pre_commit import (
     LanguagePreCommitConfigInstallResult,
 )
 from secureli.services.language_support import LanguageSupportService
+
+test_folder_path = Path(".")
 
 
 @pytest.fixture()
@@ -47,7 +50,7 @@ def test_that_language_support_attempts_to_install_pre_commit_hooks(
     language_support_service: LanguageSupportService,
     mock_pre_commit_hook: MagicMock,
 ):
-    metadata = language_support_service.apply_support("RadLang")
+    metadata = language_support_service.apply_support(test_folder_path, "RadLang")
 
     mock_pre_commit_hook.install.assert_called_once_with("RadLang")
     assert metadata.security_hook_id == "baddie-finder"

--- a/tests/services/test_logging_service.py
+++ b/tests/services/test_logging_service.py
@@ -64,7 +64,7 @@ def test_that_logging_service_success_creates_logs_folder_if_not_exists(
         overall_language="RadLang", version_installed="abc123"
     )
     mock_pre_commit.get_configuration.return_value = HookConfiguration(repos=[])
-    logging_service.success(Path(".secureli/logs/fancy-branch"), LogAction.init)
+    logging_service.success(test_folder_path, LogAction.init)
 
     mock_path.parent.mkdir.assert_called_once()
 

--- a/tests/services/test_logging_service.py
+++ b/tests/services/test_logging_service.py
@@ -8,6 +8,8 @@ from secureli.abstractions.pre_commit import HookConfiguration
 from secureli.repositories.secureli_config import SecureliConfig
 from secureli.services.logging import LoggingService, LogAction
 
+test_folder_path = Path(".")
+
 
 @pytest.fixture()
 def mock_path(mocker: MockerFixture) -> MagicMock:
@@ -62,7 +64,7 @@ def test_that_logging_service_success_creates_logs_folder_if_not_exists(
         overall_language="RadLang", version_installed="abc123"
     )
     mock_pre_commit.get_configuration.return_value = HookConfiguration(repos=[])
-    logging_service.success(LogAction.init)
+    logging_service.success(Path(".secureli/logs/fancy-branch"), LogAction.init)
 
     mock_path.parent.mkdir.assert_called_once()
 
@@ -77,7 +79,9 @@ def test_that_logging_service_failure_creates_logs_folder_if_not_exists(
         overall_language=None, version_installed=None
     )
 
-    logging_service.failure(LogAction.init, "Horrible Failure", None, None)
+    logging_service.failure(
+        test_folder_path, LogAction.init, "Horrible Failure", None, None
+    )
 
     mock_path.parent.mkdir.assert_called_once()
 
@@ -93,6 +97,6 @@ def test_that_logging_service_success_logs_none_for_hook_config_if_not_initializ
         overall_language=None, version_installed=None
     )
 
-    log_entry = logging_service.success(LogAction.build)
+    log_entry = logging_service.success(test_folder_path, LogAction.build)
 
     assert log_entry.hook_config is None

--- a/tests/services/test_updater_service.py
+++ b/tests/services/test_updater_service.py
@@ -1,9 +1,12 @@
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
 from secureli.abstractions.pre_commit import ExecuteResult
 from secureli.services.updater import UpdaterService
+
+test_folder_path = Path(".")
 
 
 @pytest.fixture()
@@ -23,7 +26,7 @@ def test_that_updater_service_update_updates_and_prunes_with_pre_commit(
     mock_pre_commit.remove_unused_hooks.return_value = ExecuteResult(
         successful=True, output=output
     )
-    update_result = updater_service.update()
+    update_result = updater_service.update(test_folder_path)
 
     mock_pre_commit.update.assert_called_once()
     mock_pre_commit.remove_unused_hooks.assert_called_once()
@@ -39,7 +42,7 @@ def test_that_updater_service_update_does_not_prune_if_no_updates(
     mock_pre_commit.remove_unused_hooks.return_value = ExecuteResult(
         successful=True, output=output
     )
-    update_result = updater_service.update()
+    update_result = updater_service.update(test_folder_path)
 
     mock_pre_commit.update.assert_called_once()
     mock_pre_commit.remove_unused_hooks.assert_not_called()
@@ -55,7 +58,7 @@ def test_that_updater_service_update_handles_failure_to_update_config(
         successful=False, output=output
     )
 
-    update_result = updater_service.update()
+    update_result = updater_service.update(test_folder_path)
 
     mock_pre_commit.install.assert_called_once()
     mock_pre_commit.update.assert_not_called()
@@ -75,7 +78,7 @@ def test_that_updater_service_update_hooks_updates_with_pre_commit(
     mock_pre_commit.remove_unused_hooks.return_value = ExecuteResult(
         successful=True, output=output
     )
-    update_result = updater_service.update_hooks()
+    update_result = updater_service.update_hooks(test_folder_path)
 
     mock_pre_commit.autoupdate_hooks.assert_called_once()
     assert update_result.successful
@@ -92,7 +95,7 @@ def test_that_updater_service_update_hooks_handles_no_updates_successfully(
     mock_pre_commit.remove_unused_hooks.return_value = ExecuteResult(
         successful=True, output=output
     )
-    update_result = updater_service.update_hooks()
+    update_result = updater_service.update_hooks(test_folder_path)
 
     mock_pre_commit.autoupdate_hooks.assert_called_once()
     assert update_result.successful

--- a/tests/utilities/test_git_meta.py
+++ b/tests/utilities/test_git_meta.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from subprocess import CompletedProcess
 from unittest.mock import MagicMock
 
@@ -5,6 +6,8 @@ import pytest
 from pytest_mock import MockerFixture
 
 from secureli.utilities.git_meta import git_user_email, origin_url, current_branch_name
+
+test_folder_path = Path(".")
 
 
 @pytest.fixture()
@@ -51,16 +54,16 @@ def test_git_user_email_loads_user_email_via_git_subprocess(mock_subprocess: Mag
 
 
 def test_origin_url_parses_config_to_get_origin_url(mock_configparser: MagicMock):
-    result = origin_url()
+    result = origin_url(test_folder_path)
 
-    mock_configparser.read.assert_called_once_with(".git/config")
+    mock_configparser.read.assert_called_once_with(f"{test_folder_path}/.git/config")
     assert result == "https://fake-build.com/git/repo"
 
 
 def test_current_branch_name_finds_ref_name_from_head_file(
     mock_open_git_head: MagicMock,
 ):
-    result = current_branch_name()
+    result = current_branch_name(test_folder_path)
 
     assert result == "feature/wicked-sick-branch"
 
@@ -68,6 +71,6 @@ def test_current_branch_name_finds_ref_name_from_head_file(
 def test_current_branch_name_yields_unknown_due_to_io_error(
     mock_open_io_error: MagicMock,
 ):
-    result = current_branch_name()
+    result = current_branch_name(test_folder_path)
 
     assert result == "UNKNOWN"


### PR DESCRIPTION
This will add the ability to the 3 commands `init` `scan` `update` with `--directory`
example:

`secureli scan -m all-files --directory ~/src/testrepo`