### PR TITLE
chore: reduce semver version

### DIFF
--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -69,7 +69,7 @@ jobs:
         pip install python-semantic-release
         git config user.name github-actions
         git config user.email github-actions@github.com
-        semantic-release publish --verbose
+        semantic-release -vv publish
     # A NOOP run on feature branches
     - name: Verify Semantic Release
       if: github.ref != 'refs/heads/main'
@@ -79,7 +79,7 @@ jobs:
         pip install python-semantic-release
         git config user.name github-actions
         git config user.email github-actions@github.com
-        semantic-release publish --noop --verbose
+        semantic-release publish -vv --noop
 
   secureli-publish:
     name: Upload release to PyPI

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -66,6 +66,7 @@ jobs:
       env:
         GH_TOKEN: ${{ steps.app_token.outputs.token }}
       run: |
+        set -x
         pip install python-semantic-release
         git config user.name github-actions
         git config user.email github-actions@github.com
@@ -77,6 +78,7 @@ jobs:
       env:
         GH_TOKEN: ${{ steps.app_token.outputs.token }}
       run: |
+        set -x
         pip install python-semantic-release
         git config user.name github-actions
         git config user.email github-actions@github.com

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -69,7 +69,7 @@ jobs:
         pip install python-semantic-release
         git config user.name github-actions
         git config user.email github-actions@github.com
-        semantic-release publish
+        semantic-release publish --verbose
     # A NOOP run on feature branches
     - name: Verify Semantic Release
       if: github.ref != 'refs/heads/main'
@@ -79,7 +79,7 @@ jobs:
         pip install python-semantic-release
         git config user.name github-actions
         git config user.email github-actions@github.com
-        semantic-release publish --noop
+        semantic-release publish --noop --verbose
 
   secureli-publish:
     name: Upload release to PyPI

--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -3,7 +3,7 @@
 # These jobs are specifically designed to test the codebase
 # and ensure that basic contributing from both mac and windows will work
 # Once both windows and mac builds are successful, the next steps will
-# - version the code, pushing the version back to the repo
+# - using semantic-version will version the code, pushing the version back to the repo
 # - push a package to pypi
 # - push a formula to the homebrew repo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ coverage = ">=6.5,<8.0"
 black = ">=22.10,<24.0"
 identify = "^2.5.7"
 poethepoet = ">=0.16.4,<0.22.0"
-python-semantic-release = "v7.34.6"
+python-semantic-release = "v8.0.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ coverage = ">=6.5,<8.0"
 black = ">=22.10,<24.0"
 identify = "^2.5.7"
 poethepoet = ">=0.16.4,<0.22.0"
-python-semantic-release = "v8.0.3"
+python-semantic-release = "8.0.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ coverage = ">=6.5,<8.0"
 black = ">=22.10,<24.0"
 identify = "^2.5.7"
 poethepoet = ">=0.16.4,<0.22.0"
-python-semantic-release = ">=7.33.1,<9.0.0"
+python-semantic-release = ">=7.33.1,<8.0.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ coverage = ">=6.5,<8.0"
 black = ">=22.10,<24.0"
 identify = "^2.5.7"
 poethepoet = ">=0.16.4,<0.22.0"
-python-semantic-release = ">=7.33.1,<8.0.0"
+python-semantic-release = "v7.34.6"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ secureli_init = "secureli init -y"
 install = "poetry install"
 lint = "black --check ."
 precommit = "pre-commit run -a"
-test = ["init", "lint", "coverage_run", "coverage_html"]
+test = ["init", "lint", "coverage_run", "coverage_report"]
 e2e = "bats tests/end-to-end/test.bats"
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ coverage = ">=6.5,<8.0"
 black = ">=22.10,<24.0"
 identify = "^2.5.7"
 poethepoet = ">=0.16.4,<0.22.0"
-python-semantic-release = "8.0.3"
+python-semantic-release = ">7.33.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
I think semver 8+ needs a pydantic version we aren't using. I don't know why we aren't getting better versioning errors but let's see what pinning to a 7.x version does for us.