### PR TITLE
fix: unintended breaking change with logging function

### DIFF
--- a/secureli/services/logging.py
+++ b/secureli/services/logging.py
@@ -97,13 +97,15 @@ class LoggingService:
         self,
         action: LogAction,
         details: str,
-        total_failure_count: Optional[int],
-        individual_failure_count: Optional[object],
+        total_failure_count: Optional[int] = None,
+        individual_failure_count: Optional[object] = None,
     ) -> LogEntry:
         """
         Capture a failure against an action, with details
         :param action: The action that failed
         :param details: Details about the failure
+        :param total_failure_count: The total failure count
+        :param individual_failure_count: The individual failure count
         """
         secureli_config = self.secureli_config.load()
         hook_config = (


### PR DESCRIPTION
The logging failure function was given two new arguments that were intended to be optional, but they were accidentally made required. Existing calls providing two arguments were no longer compatible with the function, which now required four.

Failures during initialization or upgrade were causing crashes.