### PR TITLE
chore: Adds the step to upload to gh releases

### DIFF
--- a/.github/workflows/secureliCI.yml
+++ b/.github/workflows/secureliCI.yml
@@ -110,8 +110,16 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.ADMIN_TOKEN_SASCHA }}
+
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@master
+        id: release
+        uses: python-semantic-release/python-semantic-release@v8.0.0
+        with:
+          github_token: ${{ secrets.ADMIN_TOKEN_SASCHA }}
+
+      - name: Publish package distributions to GitHub Releases
+        uses: python-semantic-release/upload-to-gh-release@main
+        if: steps.release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.ADMIN_TOKEN_SASCHA }}
 


### PR DESCRIPTION
The new version of semantic release separated the steps to create a new release and upload the release assets.  This should fix the issue with homebrew release.

https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html