### PR TITLE
chore: ensure tests run after other publish jobs finish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,4 +144,9 @@ jobs:
 
   integration-testing:
     name: Integration Testing
+    needs: [ build-test, secureli-release, secureli-publish, deploy ]
+    if: |
+      always() && 
+      (needs.secureli-publish.result == 'success' || needs.secureli-publish.result == 'skipped') &&
+      (needs.deploy.result == 'success' || needs.deploy.result == 'skipped')
     uses: ./.github/workflows/integration_testing.yml


### PR DESCRIPTION
adds needs block and if condition to run tests after other jobs complete