### PR TITLE
chore: Issue 159 - Using latest git hooks

### DIFF
--- a/secureli/main.py
+++ b/secureli/main.py
@@ -64,6 +64,7 @@ def init(
     """
     SecureliConfig.FOLDER_PATH = Path(directory)
     container.initializer_action().initialize_repo(Path(directory), reset, yes)
+    update()
 
 
 @app.command()

--- a/secureli/services/updater.py
+++ b/secureli/services/updater.py
@@ -54,7 +54,7 @@ class UpdaterService:
             output = "No changes necessary.\n"
 
         if update_result.successful and update_result.output:
-            prune_result = self.pre_commit.remove_unused_hooks()
+            prune_result = self.pre_commit.remove_unused_hooks(folder_path)
             output = output + "\nRemoving unused environments:\n" + prune_result.output
 
         return UpdateResult(successful=update_result.successful, output=output)


### PR DESCRIPTION
https://github.com/slalombuild/secureli/issues/159

[Pre-commit does not support using a latest tag](https://pre-commit.com/#using-the-latest-version-for-a-repository), the only way to use latest is to update after install.

I tested these changes by updating the version I installed with brew re-initializing a test repo with javascript and python code. It looks like the fix I made to the update command could use a regression test, that line of code cannot run without a folder path argument.