### PR TITLE
feat: add version option functionality

### DIFF
--- a/secureli/main.py
+++ b/secureli/main.py
@@ -11,6 +11,7 @@ from secureli.abstractions.echo import Color
 from secureli.resources import read_resource
 from secureli.settings import Settings
 import secureli.repositories.secureli_config as SecureliConfig
+from secureli.utilities.secureli_meta import secureli_version
 
 # Create SetupAction outside of DI, as it's not yet available.
 setup_action = SetupAction(epilog_template_data=read_resource("epilog.md"))
@@ -22,8 +23,19 @@ container = Container()
 container.config.from_pydantic(Settings())
 
 
+def version_callback(value: bool):
+    if value:
+        typer.echo(secureli_version())
+        raise typer.Exit()
+
+
 @app.callback()
-def setup():
+def setup(
+    version: Annotated[
+        Optional[bool],
+        Option("--version", "-v", callback=version_callback, is_eager=True),
+    ] = None,
+):
     """
     seCureLI:
     Secure Project Manager :sparkles:

--- a/tests/application/test_main.py
+++ b/tests/application/test_main.py
@@ -1,10 +1,12 @@
 from unittest.mock import MagicMock
+from typer.testing import CliRunner
 
 import pytest
 from pytest_mock import MockerFixture
 
 import secureli.container
 import secureli.main
+from secureli.utilities.secureli_meta import secureli_version
 
 
 @pytest.fixture()
@@ -42,3 +44,16 @@ def test_that_update_is_tbd(mock_container: MagicMock):
     secureli.main.update()
 
     mock_container.update_action.assert_called_once()
+
+
+@pytest.mark.parametrize("test_input", ["-v", "--version"])
+def test_that_app_implements_version_option(
+    test_input: str, request: pytest.FixtureRequest
+):
+    result = CliRunner().invoke(secureli.main.app, [test_input])
+    mock_container = request.getfixturevalue("mock_container")
+
+    assert result.exit_code is 0
+    assert secureli_version() in result.stdout
+    mock_container.init_resources.assert_not_called()
+    mock_container.wire.assert_not_called()


### PR DESCRIPTION
closes #170 

Adds option to display the current seCureLI version in the terminal using either `-v` or `--version`