### PR TITLE
fix: Correctly parsing %-encoded URLs from .git/config file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,6 +289,7 @@ A special thanks to everyone that has contributed to seCureLI so far:
 - Korey Earl
 - Martin Gallegos
 - Ryan Graue
+- Tyler Durkota
 - Jordan Hill
 - Kira Hollerman
 - Myung Kim

--- a/secureli/utilities/git_meta.py
+++ b/secureli/utilities/git_meta.py
@@ -15,7 +15,7 @@ def origin_url() -> str:
     git_config_parser = configparser.ConfigParser()
     git_config_parser.read(".git/config")
     return (
-        git_config_parser['remote "origin"'].get("url", "UNKNOWN")
+        git_config_parser['remote "origin"'].get("url", "UNKNOWN", raw=True)
         if git_config_parser.has_section('remote "origin"')
         else "UNKNOWN"
     )

--- a/tests/utilities/test_git_meta.py
+++ b/tests/utilities/test_git_meta.py
@@ -6,7 +6,8 @@ from pytest_mock import MockerFixture
 
 from secureli.utilities.git_meta import git_user_email, origin_url, current_branch_name
 
-mock_git_origin_url = r'git@github.com:my-org/repo%20with%20spaces.git'
+mock_git_origin_url = r"git@github.com:my-org/repo%20with%20spaces.git"
+
 
 @pytest.fixture()
 def mock_subprocess(mocker: MockerFixture) -> MagicMock:
@@ -41,8 +42,8 @@ def mock_open_git_head(mocker: MockerFixture) -> MagicMock:
 def mock_open_git_origin(mocker: MockerFixture) -> MagicMock:
     mock_open_git_config = mocker.mock_open(
         read_data='[remote "origin"]'
-        '\n    url = ' + mock_git_origin_url +
-        '\n    fetch = +refs/heads/*:refs/remotes/origin/*'
+        f"\n    url = {mock_git_origin_url}"
+        "\n    fetch = +refs/heads/*:refs/remotes/origin/*"
     )
     mocker.patch("builtins.open", mock_open_git_config)
     return mock_open_git_config
@@ -85,8 +86,6 @@ def test_current_branch_name_yields_unknown_due_to_io_error(
     assert result == "UNKNOWN"
 
 
-def test_configparser_can_read_origin_url_with_percent(
-    mock_open_git_origin
-):
+def test_configparser_can_read_origin_url_with_percent(mock_open_git_origin):
     assert origin_url() == mock_git_origin_url
-    mock_open_git_origin.assert_called_once_with(".git/config", encoding='locale')
+    mock_open_git_origin.assert_called_once_with(".git/config", encoding="locale")

--- a/tests/utilities/test_git_meta.py
+++ b/tests/utilities/test_git_meta.py
@@ -88,4 +88,3 @@ def test_current_branch_name_yields_unknown_due_to_io_error(
 
 def test_configparser_can_read_origin_url_with_percent(mock_open_git_origin):
     assert origin_url() == mock_git_origin_url
-    mock_open_git_origin.assert_called_once_with(".git/config", encoding="locale")

--- a/tests/utilities/test_git_meta.py
+++ b/tests/utilities/test_git_meta.py
@@ -86,5 +86,5 @@ def test_current_branch_name_yields_unknown_due_to_io_error(
     assert result == "UNKNOWN"
 
 
-def test_configparser_can_read_origin_url_with_percent(mock_open_git_origin):
+def test_configparser_can_read_origin_url_with_percent(mock_open_git_origin: MagicMock):
     assert origin_url() == mock_git_origin_url


### PR DESCRIPTION
Resolves #261

The `configparser` module by default assumes that '%' characters indicate the presence of a variable and will try to parse a config value accordingly. Switching to "raw" mode prevents this behavior.

## Testing
Manually tested by changing my `.git/config` file to set the origin URL to include `%20`, and was able to replicate the failure detailed in the ticket.