### PR TITLE
chore: Improve terminal output

### DIFF
--- a/secureli/abstractions/echo.py
+++ b/secureli/abstractions/echo.py
@@ -1,8 +1,11 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Optional
+from typing import IO, Optional
 
+import sys
 import typer
+
+from secureli.utilities.logging import EchoLevel
 
 
 class Color(str, Enum):
@@ -24,19 +27,21 @@ class EchoAbstraction(ABC):
     it harms our ability to refactor!)
     """
 
-    def __init__(self, level: str):
-        self.print_enabled = level != "OFF"
-        self.info_enabled = level in ["DEBUG", "INFO"]
-        self.warn_enabled = level in ["DEBUG", "INFO", "WARN"]
-        self.error_enabled = level in ["DEBUG", "INFO", "WARN", "ERROR"]
+    def __init__(self, level: str):  # TODO should we be using the EchoLevel enum in settings.py?
+        self.print_enabled = level != EchoLevel.off
+        self.debug_enabled = level == EchoLevel.debug
+        self.info_enabled = level in [EchoLevel.debug, EchoLevel.info]
+        self.warn_enabled = level in [EchoLevel.debug, EchoLevel.info, EchoLevel.warn]
+        self.error_enabled = level in [EchoLevel.debug, EchoLevel.info, EchoLevel.warn, EchoLevel.error]
 
     @abstractmethod
-    def _echo(self, message: str, color: Optional[Color] = None, bold: bool = False):
+    def _echo(self, message: str, color: Optional[Color] = None, bold: bool = False, fd: IO = sys.stdout):
         """
         Print the provided message to the terminal with the associated color and weight
         :param message: The message to print
         :param color: The color to use
         :param bold: Whether to make this message appear bold or not
+        :param fd: A file descriptor, defaults to stdout
         """
         pass
 
@@ -59,10 +64,16 @@ class EchoAbstraction(ABC):
         :param color: The color to use
         :param bold: Whether to make this message appear bold or not
         """
-        if not self.print_enabled:
-            return
+        if self.print_enabled:
+            self._echo(message, color, bold)
 
-        self._echo(message, color, bold)
+    def debug(self, message: str) -> None:
+        """
+        Prints the message to the terminal in light blue and bold
+        :param message: The debug message to print
+        """
+        if self.debug_enabled:
+            self._echo(f"[DEBUG] {message}", color=Color.CYAN, bold=True)
 
     def info(self, message: str, color: Optional[Color] = None, bold: bool = False):
         """
@@ -71,28 +82,24 @@ class EchoAbstraction(ABC):
         :param color: The color to use
         :param bold: Whether to make this message appear bold or not
         """
-        if not self.info_enabled:
-            return
-
-        self._echo(message, color, bold)
+        if self.info_enabled:
+            self._echo(f"[INFO] {message}", color, bold)
 
     def error(self, message: str):
         """
         Prints the provided message to the terminal in red and bold
         :param message: The error message to print
         """
-        if not self.error_enabled:
-            return
-        self._echo(message, color=Color.RED, bold=True)
+        if self.error_enabled:
+            self._echo(f"[ERROR] {message}", color=Color.RED, bold=True, fd=sys.stderr)
 
     def warning(self, message: str):
         """
         Prints the provided message to the terminal in red and bold
         :param message: The error message to print
         """
-        if not self.warn_enabled:
-            return
-        self._echo(message, color=Color.YELLOW, bold=False)
+        if self.warn_enabled:
+            self._echo(f"[WARN] {message}", color=Color.YELLOW, bold=False)
 
 
 class TyperEcho(EchoAbstraction):
@@ -100,13 +107,13 @@ class TyperEcho(EchoAbstraction):
     Encapsulates the Typer dependency for printing purposes, allows us to render stuff to the screen.
     """
 
-    def __init__(self, level: str):
+    def __init__(self, level: str) -> None:
         super().__init__(level)
 
-    def _echo(self, message: str, color: Optional[Color] = None, bold: bool = False):
+    def _echo(self, message: str, color: Optional[Color] = None, bold: bool = False, fd: IO = sys.stdout) -> None:
         fg = color.value if color else None
-        message = typer.style(message, fg=fg, bold=bold)
-        typer.echo(message)
+        message = typer.style(f"[seCureLI] {message}", fg=fg, bold=bold)
+        typer.echo(message, file=fd)
 
     def confirm(self, message: str, default_response: Optional[bool] = False) -> bool:
         return typer.confirm(message, default=default_response, show_default=True)

--- a/secureli/abstractions/echo.py
+++ b/secureli/abstractions/echo.py
@@ -27,15 +27,26 @@ class EchoAbstraction(ABC):
     it harms our ability to refactor!)
     """
 
-    def __init__(self, level: str):  # TODO should we be using the EchoLevel enum in settings.py?
+    def __init__(self, level: str):
         self.print_enabled = level != EchoLevel.off
         self.debug_enabled = level == EchoLevel.debug
         self.info_enabled = level in [EchoLevel.debug, EchoLevel.info]
         self.warn_enabled = level in [EchoLevel.debug, EchoLevel.info, EchoLevel.warn]
-        self.error_enabled = level in [EchoLevel.debug, EchoLevel.info, EchoLevel.warn, EchoLevel.error]
+        self.error_enabled = level in [
+            EchoLevel.debug,
+            EchoLevel.info,
+            EchoLevel.warn,
+            EchoLevel.error,
+        ]
 
     @abstractmethod
-    def _echo(self, message: str, color: Optional[Color] = None, bold: bool = False, fd: IO = sys.stdout):
+    def _echo(
+        self,
+        message: str,
+        color: Optional[Color] = None,
+        bold: bool = False,
+        fd: IO = sys.stdout,
+    ):
         """
         Print the provided message to the terminal with the associated color and weight
         :param message: The message to print
@@ -110,7 +121,13 @@ class TyperEcho(EchoAbstraction):
     def __init__(self, level: str) -> None:
         super().__init__(level)
 
-    def _echo(self, message: str, color: Optional[Color] = None, bold: bool = False, fd: IO = sys.stdout) -> None:
+    def _echo(
+        self,
+        message: str,
+        color: Optional[Color] = None,
+        bold: bool = False,
+        fd: IO = sys.stdout,
+    ) -> None:
         fg = color.value if color else None
         message = typer.style(f"[seCureLI] {message}", fg=fg, bold=bold)
         typer.echo(message, file=fd)

--- a/secureli/repositories/settings.py
+++ b/secureli/repositories/settings.py
@@ -1,9 +1,10 @@
-from enum import Enum
 from pathlib import Path
 from typing import Optional
+from pydantic import BaseModel, BaseSettings, Field
+from secureli.utilities.logging import EchoLevel
 
 import yaml
-from pydantic import BaseModel, BaseSettings, Field
+
 
 default_ignored_extensions = [
     # Images
@@ -68,25 +69,12 @@ class RepoFilesSettings(BaseSettings):
     exclude_file_patterns: list[str] = Field(default=[])
 
 
-class EchoLevel(str, Enum):
-    debug = "DEBUG"
-    info = "INFO"
-    warn = "WARN"
-    error = "ERROR"
-
-    def __str__(self) -> str:
-        return self.value
-
-    def __repr__(self) -> str:
-        return self.__str__()
-
-
 class EchoSettings(BaseSettings):
     """
     Settings that affect how seCureLI provides information to the user.
     """
 
-    level: EchoLevel = Field(default=EchoLevel.error)
+    level: EchoLevel = Field(default=EchoLevel.warn)
 
 
 class LanguageSupportSettings(BaseSettings):

--- a/secureli/utilities/logging.py
+++ b/secureli/utilities/logging.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class EchoLevel(str, Enum):
     debug = "DEBUG"
     info = "INFO"

--- a/secureli/utilities/logging.py
+++ b/secureli/utilities/logging.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+class EchoLevel(str, Enum):
+    debug = "DEBUG"
+    info = "INFO"
+    warn = "WARN"
+    error = "ERROR"
+    off = "OFF"
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/tests/abstractions/test_typer_echo.py
+++ b/tests/abstractions/test_typer_echo.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, ANY
 
 import pytest
 
+
 @pytest.fixture()
 def mock_echo_text() -> str:
     return "Hello, There"

--- a/tests/abstractions/test_typer_echo.py
+++ b/tests/abstractions/test_typer_echo.py
@@ -1,10 +1,8 @@
+from pytest_mock import MockerFixture
+from secureli.abstractions.echo import TyperEcho, Color
 from unittest.mock import MagicMock, ANY
 
 import pytest
-from pytest_mock import MockerFixture
-
-from secureli.abstractions.echo import TyperEcho, Color
-
 
 @pytest.fixture()
 def mock_echo_text() -> str:
@@ -55,7 +53,7 @@ def test_that_typer_echo_stylizes_message(
     typer_echo.info(mock_echo_text)
 
     mock_typer_style.assert_called_once()
-    mock_typer_echo.assert_called_once_with(mock_echo_text)
+    mock_typer_echo.assert_called_once_with(mock_echo_text, file=ANY)
 
 
 def test_that_typer_echo_stylizes_message_when_printing(
@@ -67,7 +65,7 @@ def test_that_typer_echo_stylizes_message_when_printing(
     typer_echo.print(mock_echo_text)
 
     mock_typer_style.assert_called_once()
-    mock_typer_echo.assert_called_once_with(mock_echo_text)
+    mock_typer_echo.assert_called_once_with(mock_echo_text, file=ANY)
 
 
 def test_that_typer_echo_does_not_even_print_when_off(


### PR DESCRIPTION
Implementing the following changes:
1. Add debug log level (colored cyan)
2. Make error messages print to stderr instead of stdout
3. include "[seCureLI] [\<log level\>] " prefix to messages
4. Update default log level from ERROR to WARN
5. Move log level enum to separate class and use more consistently

This is what output would look like now (with debug logging enabled):

<img width="728" alt="Screenshot 2023-11-22 132426" src="https://github.com/slalombuild/secureli/assets/1209260/e4d36e31-0f56-43e4-b034-ccf575931e65">

## Testing
Updated unit tests