### PR TITLE
feat: Handle additional installation for newly detected languages

### DIFF
--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -109,18 +109,23 @@ class Action(ABC):
                 if language not in (config.languages or [])
             ]
         except (ValueError, LanguageNotSupportedError) as e:
-            if not config.languages:
-                self.action_deps.echo.error(
-                    f"seCureLI could not be installed due to an error: {str(e)}"
+            if config.languages and config.version_installed:
+                self.action_deps.echo.warning(
+                    f"Newly detected languages are unsupported by seCureLI"
                 )
-                return VerifyResult(
-                    outcome=VerifyOutcome.INSTALL_FAILED,
-                )
+                return VerifyResult(outcome=VerifyOutcome.UP_TO_DATE, config=config)
+
+            self.action_deps.echo.error(
+                f"seCureLI could not be installed due to an error: {str(e)}"
+            )
+            return VerifyResult(
+                outcome=VerifyOutcome.INSTALL_FAILED,
+            )
 
         if (
             not config.languages
             or not config.version_installed
-            or len(newly_detected_languages or [])
+            or newly_detected_languages
         ):
             return self._install_secureli(
                 folder_path, languages, newly_detected_languages, always_yes

--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -103,11 +103,6 @@ class Action(ABC):
 
         try:
             languages = self._detect_languages(folder_path)
-            newly_detected_languages = [
-                language
-                for language in (languages or [])
-                if language not in (config.languages or [])
-            ]
         except (ValueError, LanguageNotSupportedError) as e:
             if config.languages and config.version_installed:
                 self.action_deps.echo.warning(
@@ -122,6 +117,11 @@ class Action(ABC):
                 outcome=VerifyOutcome.INSTALL_FAILED,
             )
 
+        newly_detected_languages = [
+            language
+            for language in (languages or [])
+            if language not in (config.languages or [])
+        ]
         if (
             not config.languages
             or not config.version_installed
@@ -162,8 +162,12 @@ class Action(ABC):
         )
         if not should_install:
             self.action_deps.echo.error("User canceled install process")
-            return VerifyResult(
-                outcome=VerifyOutcome.INSTALL_CANCELED,
+            return (
+                VerifyResult(
+                    outcome=VerifyOutcome.INSTALL_CANCELED,
+                )
+                if new_install
+                else VerifyResult(outcome=VerifyOutcome.UP_TO_DATE)
             )
 
         lint_languages = self._prompt_get_lint_config_languages(

--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -161,14 +161,14 @@ class Action(ABC):
             install_languages, always_yes, new_install
         )
         if not should_install:
-            self.action_deps.echo.error("User canceled install process")
-            return (
-                VerifyResult(
+            if new_install:
+                self.action_deps.echo.error("User canceled install process")
+                return VerifyResult(
                     outcome=VerifyOutcome.INSTALL_CANCELED,
                 )
-                if new_install
-                else VerifyResult(outcome=VerifyOutcome.UP_TO_DATE)
-            )
+
+            self.action_deps.echo.warning("Newly detected languages were not installed")
+            return VerifyResult(outcome=VerifyOutcome.UP_TO_DATE)
 
         lint_languages = self._prompt_get_lint_config_languages(
             install_languages, always_yes

--- a/secureli/actions/initializer.py
+++ b/secureli/actions/initializer.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from secureli.actions.scan import ScanAction
-from secureli.actions.action import Action, ActionDependencies
+from secureli.actions.action import Action, ActionDependencies, VerifyResult
 from secureli.services.logging import LoggingService, LogAction
 
 
@@ -16,7 +16,9 @@ class InitializerAction(Action):
         super().__init__(action_deps)
         self.logging = logging
 
-    def initialize_repo(self, folder_path: Path, reset: bool, always_yes: bool):
+    def initialize_repo(
+        self, folder_path: Path, reset: bool, always_yes: bool
+    ) -> VerifyResult:
         """
         Initializes seCureLI for the specified folder path
         :param folder_path: The folder path to initialize the repo for
@@ -39,3 +41,5 @@ class InitializerAction(Action):
             self.logging.failure(LogAction.init, verify_result.outcome)
         else:
             self.logging.success(LogAction.init)
+
+        return verify_result

--- a/secureli/main.py
+++ b/secureli/main.py
@@ -3,6 +3,7 @@ from typing import Optional
 from typing_extensions import Annotated
 import typer
 from typer import Option
+from secureli.actions.action import VerifyOutcome
 
 from secureli.actions.scan import ScanMode
 from secureli.actions.setup import SetupAction
@@ -75,8 +76,17 @@ def init(
     Detect languages and initialize pre-commit hooks and linters for the project
     """
     SecureliConfig.FOLDER_PATH = Path(directory)
-    container.initializer_action().initialize_repo(Path(directory), reset, yes)
-    update()
+
+    init_result = container.initializer_action().initialize_repo(
+        Path(directory), reset, yes
+    )
+    if init_result.outcome in [
+        VerifyOutcome.INSTALL_SUCCEEDED,
+        VerifyOutcome.UP_TO_DATE,
+        VerifyOutcome.UPDATE_SUCCEEDED,
+        VerifyOutcome.UPGRADE_SUCCEEDED,
+    ]:
+        update()
 
 
 @app.command()

--- a/secureli/repositories/secureli_config.py
+++ b/secureli/repositories/secureli_config.py
@@ -10,7 +10,6 @@ FOLDER_PATH = Path(".")
 
 class SecureliConfig(BaseModel):
     languages: Optional[list[str]]
-    lint_languages: Optional[list[str]]
     version_installed: Optional[str]
 
 
@@ -97,7 +96,6 @@ class SecureliConfigRepository:
 
         return SecureliConfig(
             languages=[old_config.overall_language],
-            lint_languages=[old_config.overall_language],
             version_installed=old_config.version_installed,
         )
 

--- a/secureli/services/language_support.py
+++ b/secureli/services/language_support.py
@@ -117,7 +117,9 @@ class LanguageSupportService:
         as well as a secret-detection hook ID, if present.
         """
 
-        path_to_pre_commit_file = Path(SecureliConfig.FOLDER_PATH / ".pre-commit-config.yaml")
+        path_to_pre_commit_file = Path(
+            SecureliConfig.FOLDER_PATH / ".pre-commit-config.yaml"
+        )
 
         if len(language_config_result.linter_configs) > 0:
             self._write_pre_commit_configs(language_config_result.linter_configs)

--- a/tests/actions/test_action.py
+++ b/tests/actions/test_action.py
@@ -274,6 +274,25 @@ def test_that_initialize_repo_is_aborted_by_the_user_if_the_process_is_canceled(
     mock_echo.error.assert_called_with("User canceled install process")
 
 
+def test_that_initialize_repo_returns_up_to_date_if_the_process_is_canceled_on_existing_install(
+    action: Action,
+    mock_secureli_config: MagicMock,
+    mock_language_analyzer: MagicMock,
+    mock_echo: MagicMock,
+):
+    # User elects to cancel the process
+    mock_echo.confirm.return_value = False
+    mock_secureli_config.load.return_value = SecureliConfig(
+        languages=["RadLang"], version_installed="abc123"
+    )
+    mock_language_analyzer.analyze.return_value = AnalyzeResult(
+        language_proportions={"RadLang": 0.5, "CoolLang": 0.5}, skipped_files=[]
+    )
+
+    result = action.verify_install(test_folder_path, reset=False, always_yes=False)
+    assert result.outcome == VerifyOutcome.UP_TO_DATE
+
+
 def test_that_verify_install_returns_failed_result_on_new_install_language_not_supported(
     action: Action,
     mock_secureli_config: MagicMock,

--- a/tests/actions/test_action.py
+++ b/tests/actions/test_action.py
@@ -82,7 +82,7 @@ def test_that_initialize_repo_install_flow_selects_both_languages(
     action.verify_install(test_folder_path, reset=True, always_yes=True)
 
     mock_echo.print.assert_called_with(
-        "seCureLI has been installed successfully (languages = ['RadLang', 'CoolLang'])"
+        "seCureLI has been installed successfully (languages = RadLang, CoolLang)"
     )
 
 
@@ -183,7 +183,12 @@ def test_that_initialize_repo_selects_previously_selected_language(
     mock_secureli_config: MagicMock,
     mock_language_support: MagicMock,
     mock_echo: MagicMock,
+    mock_language_analyzer: MagicMock,
 ):
+    mock_language_analyzer.analyze.return_value = AnalyzeResult(
+        language_proportions={"PreviousLang": 1.0},
+        skipped_files=[],
+    )
     mock_secureli_config.load.return_value = SecureliConfig(
         languages=["PreviousLang"], version_installed="abc123"
     )
@@ -191,7 +196,7 @@ def test_that_initialize_repo_selects_previously_selected_language(
 
     action.verify_install(test_folder_path, reset=False, always_yes=True)
 
-    mock_echo.print.assert_called_once_with(
+    mock_echo.print.assert_called_with(
         "seCureLI is installed and up-to-date (languages = ['PreviousLang'])"
     )
 
@@ -216,8 +221,12 @@ def test_that_initialize_repo_updates_repo_config_if_old_schema(
     action: Action,
     mock_secureli_config: MagicMock,
     mock_language_support: MagicMock,
-    mock_echo: MagicMock,
+    mock_language_analyzer: MagicMock,
 ):
+    mock_language_analyzer.analyze.return_value = AnalyzeResult(
+        language_proportions={"PreviousLang": 1.0},
+        skipped_files=[],
+    )
     mock_secureli_config.verify.return_value = VerifyConfigOutcome.OUT_OF_DATE
 
     mock_secureli_config.update.return_value = SecureliConfig(

--- a/tests/actions/test_scan_action.py
+++ b/tests/actions/test_scan_action.py
@@ -13,6 +13,7 @@ from secureli.repositories.settings import (
     EchoSettings,
     EchoLevel,
 )
+from secureli.services.language_analyzer import AnalyzeResult
 from secureli.services.scanner import ScanMode, ScanResult, Failure
 
 test_folder_path = Path("does-not-matter")
@@ -129,8 +130,12 @@ def test_that_scan_repo_scans_if_installed(
     mock_secureli_config: MagicMock,
     mock_language_support: MagicMock,
     mock_scanner: MagicMock,
-    mock_echo: MagicMock,
+    mock_language_analyzer: MagicMock,
 ):
+    mock_language_analyzer.analyze.return_value = AnalyzeResult(
+        language_proportions={"RadLang": 1.0},
+        skipped_files=[],
+    )
     mock_secureli_config.load.return_value = SecureliConfig(
         languages=["RadLang"], version_installed="abc123"
     )
@@ -148,7 +153,12 @@ def test_that_scan_repo_continue_scan_if_upgrade_canceled(
     mock_language_support: MagicMock,
     mock_scanner: MagicMock,
     mock_echo: MagicMock,
+    mock_language_analyzer: MagicMock,
 ):
+    mock_language_analyzer.analyze.return_value = AnalyzeResult(
+        language_proportions={"RadLang": 1.0},
+        skipped_files=[],
+    )
     mock_secureli_config.load.return_value = SecureliConfig(
         languages=["RadLang"], version_installed="abc123"
     )

--- a/tests/application/test_main.py
+++ b/tests/application/test_main.py
@@ -3,6 +3,7 @@ from typer.testing import CliRunner
 
 import pytest
 from pytest_mock import MockerFixture
+from secureli.actions.action import VerifyOutcome, VerifyResult
 
 import secureli.container
 import secureli.main
@@ -66,3 +67,45 @@ def test_that_app_ignores_version_callback(mock_container: MagicMock):
     assert secureli_version() not in result.stdout
     mock_container.init_resources.assert_called_once()
     mock_container.wire.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        VerifyOutcome.INSTALL_SUCCEEDED,
+        VerifyOutcome.UPDATE_SUCCEEDED,
+        VerifyOutcome.UP_TO_DATE,
+        VerifyOutcome.UPGRADE_SUCCEEDED,
+    ],
+)
+def test_that_successful_init_runs_update(
+    test_input: VerifyOutcome, mock_container: MagicMock
+):
+    mock_container.initializer_action.return_value.initialize_repo.return_value = (
+        VerifyResult(outcome=test_input)
+    )
+    secureli.main.init()
+
+    mock_container.update_action.return_value.update_hooks.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        VerifyOutcome.INSTALL_CANCELED,
+        VerifyOutcome.INSTALL_FAILED,
+        VerifyOutcome.UPDATE_CANCELED,
+        VerifyOutcome.UPDATE_FAILED,
+        VerifyOutcome.UPGRADE_CANCELED,
+        VerifyOutcome.UPGRADE_FAILED,
+    ],
+)
+def test_that_unsuccessful_init_does_not_run_update(
+    test_input: VerifyOutcome, mock_container: MagicMock
+):
+    mock_container.initializer_action.return_value.initialize_repo.return_value = (
+        VerifyResult(outcome=test_input)
+    )
+    secureli.main.init()
+
+    mock_container.update_action.return_value.update_hooks.assert_not_called()

--- a/tests/services/test_language_support.py
+++ b/tests/services/test_language_support.py
@@ -252,7 +252,9 @@ def test_that_language_support_writes_linter_config_files(
         languages, lint_languages
     )
 
-    metadata = language_support_service.apply_support(["RadLang"], build_config_result)
+    metadata = language_support_service.apply_support(
+        ["RadLang"], build_config_result, overwrite_pre_commit=True
+    )
 
     assert metadata.security_hook_id == "baddie-finder"
 
@@ -287,7 +289,9 @@ def test_that_language_support_throws_exception_when_language_config_file_cannot
     mock_open.side_effect = IOError
 
     with raises(IOError):
-        language_support_service.apply_support(languages, build_config_result)
+        language_support_service.apply_support(
+            languages, build_config_result, overwrite_pre_commit=True
+        )
 
 
 def test_that_language_support_handles_invalid_language_config(
@@ -313,7 +317,9 @@ def test_that_language_support_handles_invalid_language_config(
         languages, lint_languages
     )
 
-    metadata = language_support_service.apply_support(languages, build_config_result)
+    metadata = language_support_service.apply_support(
+        languages, build_config_result, overwrite_pre_commit=True
+    )
     assert metadata.security_hook_id is None
 
 


### PR DESCRIPTION
closes #187 

During either a scan or install, users will be prompted to install any newly detected languages:
<img width="678" alt="Screenshot 2023-12-19 at 3 50 39 PM" src="https://github.com/slalombuild/secureli/assets/58826693/9f20b56f-8ae2-4367-8ef0-db4246bea647">

If the user cancels the additional language install or an error occurs during language detection, the process will continue for the existing installed languages with a warning:

<img width="747" alt="Screenshot 2023-12-19 at 4 49 11 PM" src="https://github.com/slalombuild/secureli/assets/58826693/12feaa9a-6899-4103-b299-3e0d945351c9">



