### PR TITLE
chore: replace unsupported google eslint with eslint recommended

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "secureli"
-version = "0.20.0"
+version = "0.21.0"
 description = "Secure Project Manager"
 authors = ["Caleb Tonn <caleb.tonn@slalom.com>"]
 license = "Apache-2.0"

--- a/scripts/get-secureli-dependencies.py
+++ b/scripts/get-secureli-dependencies.py
@@ -18,7 +18,6 @@ packagesToRemoveFromFormula = [
     "shellingham",
     "distlib",
     "filelock",
-    "identify",
     "nodeenv",
     "platformdirs",
     "setuptools",

--- a/secureli/resources/files/configs/javascript.config.yaml
+++ b/secureli/resources/files/configs/javascript.config.yaml
@@ -1,4 +1,4 @@
-filename: ".eslintrc.yaml"
+filename: "javascript.eslintrc.yaml"
 settings:
   extends: ["eslint:recommended"]
   env:

--- a/secureli/resources/files/configs/javascript.config.yaml
+++ b/secureli/resources/files/configs/javascript.config.yaml
@@ -1,6 +1,6 @@
 filename: ".eslintrc.yaml"
 settings:
-  extends: ["google"]
+  extends: ["eslint:recommended"]
   env:
     es6: true
   plugins: ["prettier"]

--- a/secureli/resources/files/configs/typescript.config.yaml
+++ b/secureli/resources/files/configs/typescript.config.yaml
@@ -1,5 +1,5 @@
 filename: ".eslintrc.yaml"
 settings:
-  extends: ["google", "plugin:@typescript-eslint/recommended", "prettier"]
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"]
   parser: "@typescript-eslint/parser"
   plugins: ["@typescript-eslint"]

--- a/secureli/resources/files/configs/typescript.config.yaml
+++ b/secureli/resources/files/configs/typescript.config.yaml
@@ -1,4 +1,4 @@
-filename: ".eslintrc.yaml"
+filename: "typescript.eslintrc.yaml"
 settings:
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"]
   parser: "@typescript-eslint/parser"

--- a/secureli/resources/files/pre-commit/lint/javascript-pre-commit.yaml
+++ b/secureli/resources/files/pre-commit/lint/javascript-pre-commit.yaml
@@ -5,10 +5,9 @@ repos:
       - id: eslint
         files: \.[j]sx?$ # *.js and *.jsx
         types: [file]
-        args: ["--config", ".secureli/javascript.eslintrc.yaml", "--fix"]
+        args: ["--config", ".eslintrc.yaml", "--fix"]
         additional_dependencies:
           - eslint@8.42.0
-          - eslint-config-google@0.7.1
           - eslint-plugin-prettier@4.2.1
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v2.7.1"

--- a/secureli/resources/files/pre-commit/lint/javascript-pre-commit.yaml
+++ b/secureli/resources/files/pre-commit/lint/javascript-pre-commit.yaml
@@ -5,7 +5,7 @@ repos:
       - id: eslint
         files: \.[j]sx?$ # *.js and *.jsx
         types: [file]
-        args: ["--config", ".eslintrc.yaml", "--fix"]
+        args: ["--config", "javascript.eslintrc.yaml", "--fix"]
         additional_dependencies:
           - eslint@8.42.0
           - eslint-plugin-prettier@4.2.1

--- a/secureli/resources/files/pre-commit/lint/typescript-pre-commit.yaml
+++ b/secureli/resources/files/pre-commit/lint/typescript-pre-commit.yaml
@@ -5,13 +5,14 @@ repos:
       - id: eslint
         files: \.[t]sx?$ # *.ts and *.tsx
         types: [file]
-        args: ["--config", ".eslintrc.yaml", "--fix"]
+        args: ["--config", "typescript.eslintrc.yaml", "--fix"]
         additional_dependencies:
           - eslint@8.42.0
           - "@typescript-eslint/eslint-plugin@5.59.11"
           - "@typescript-eslint/parser@5.59.11"
           - typescript@5.1.3
           - eslint-config-prettier@8.8.0
+          - eslint-plugin-prettier@4.2.1
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v2.7.1"
     hooks:

--- a/secureli/resources/files/pre-commit/lint/typescript-pre-commit.yaml
+++ b/secureli/resources/files/pre-commit/lint/typescript-pre-commit.yaml
@@ -5,10 +5,9 @@ repos:
       - id: eslint
         files: \.[t]sx?$ # *.ts and *.tsx
         types: [file]
-        args: ["--config", ".secureli/typescript.eslintrc.yaml", "--fix"]
+        args: ["--config", ".eslintrc.yaml", "--fix"]
         additional_dependencies:
           - eslint@8.42.0
-          - eslint-config-google@0.7.1
           - "@typescript-eslint/eslint-plugin@5.59.11"
           - "@typescript-eslint/parser@5.59.11"
           - typescript@5.1.3


### PR DESCRIPTION
closes #337

- Replace the `eslint-google-config` settings with `eslint:recommended` for generated typescript and javascript eslint config files.


- Add missing module `identify` to homebrew formula

- Fix lint config issues

   1. Fix mismatched file names in pre-commit file and config files
   2. Create separate files for JavaScript and TypeScript
   3. Add missing dependency for needed TypeScript pre-commit file