### PR TITLE
docs: Update documentation to describe release prefixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,12 @@ Like this:
 `chore: my PR title`
 
 Valid prefixes are defined in the [angular documentation](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit)
-_Important: Use "feat" to have a release automatically published. "fix,perf,docs,chore,chore(release)" only creates a patch
-version which does not get automatically released._
+
+| :memo:        | Note       |
+|---------------|:-----------|
+
+> _Use "feat" to cut a minor release automatically. "fix", "perf", or "chore(release)" will create a patch release.
+ Note that "build", "chore", "ci", "docs", "style", "refactor", and "test" do not create a release._
 
 # Environment Requirements
 


### PR DESCRIPTION
Minor update to documentation to as a follow-up to #366

Screenshot:
<img width="768" alt="Screenshot 2024-01-16 104221" src="https://github.com/slalombuild/secureli/assets/1209260/d1e7a10a-22ac-42c9-9ab0-65fd97e33feb">
