### PR TITLE
fix: remove cfgv from homebrew exclude list

### DIFF
--- a/scripts/get-secureli-dependencies.py
+++ b/scripts/get-secureli-dependencies.py
@@ -13,6 +13,7 @@ secureliPackageUrl = f"https://github.com/slalombuild/secureli/releases/download
 secureliPackageDependencies = []
 secureliFormulaPath = "./homebrew-secureli/Formula"
 # Filter out additional packages that are needed for the pip package, but not the homebrew formula
+# Unneeded packages are removed from the homebrew formula in order to minimize secureli homebrew installation time
 packagesToRemoveFromFormula = [
     "colorama",
     "shellingham",
@@ -22,7 +23,6 @@ packagesToRemoveFromFormula = [
     "platformdirs",
     "setuptools",
     "virtualenv",
-    "cfgv",
 ]
 
 secureliPackageNamesCmd = "poetry show --only main | awk '{print $1}'"


### PR DESCRIPTION
closes #368 

remove cfgv from exclude list so that it is added to homebrew formula