### PR TITLE
fix: Restrict to python 3.11 & lower in pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1134,5 +1134,5 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9"
-content-hash = "8ec63ecb80b96ca145b7f81845273eaebfe955a4ca157f01df4cb26f0e9046af"
+python-versions = ">= 3.9, < 3.12"
+content-hash = "2cf2a52be05f4d8e8e75d7b4e0ca8e7f4f7aa84a7253b4179c01358ae9769134"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "secureli"
 version = "0.21.5"
@@ -26,7 +30,8 @@ test = ["init", "lint", "coverage_run", "coverage_report"]
 e2e = "bats tests/end-to-end/test.bats"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+# Until `python-dependency-injector` supports python 3.12, restrict to python 3.11 and lower
+python = ">= 3.9, < 3.12"
 typer = {version = ">=0.6.1,<0.10.0", extras = ["all"]}
 pygments = "^2.13.0"
 # Uncomment the following line to enable python 3.12 support prior to dependency-injector officially supporting it
@@ -52,10 +57,6 @@ black = ">=22.10,<24.0"
 identify = "^2.5.7"
 poethepoet = ">=0.16.4,<0.25.0"
 python-semantic-release = ">=8.0.0"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
 
 [tool.semantic_release]
 # Documentation for these options: https://python-semantic-release.readthedocs.io/en/latest/configuration.html


### PR DESCRIPTION
By restricting the supported python range, we can fix `poetry shell && poetry install` to not attempt to install secureli on python 3.12.

I'm also hoping that once this gets released it will update the [PyPI listing](https://pypi.org/project/secureli/) to not include python 3.12 in the supported python versions.

I also moved up the `[build-system]` block to the top of `pyproject.toml`, since it's a top-level & required section.

## Testing

```
% poetry env use 3.12
Using virtualenv: /Users/tyler.durkota/Library/Caches/pypoetry/virtualenvs/secureli-TKSW7H2l-py3.12
% poetry shell

Current Python version (3.12.1) is not allowed by the project (>= 3.9, < 3.12).
Please change python executable via the "env use" command.
```