### PR TITLE
fix: Feature/secureli 386 homebrew tests failing

### DIFF
--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -46,9 +46,8 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
-          brew install \
-          pre-commit \
-          python@3.9
+          brew install pre-commit
+          brew install python@3.9
         continue-on-error: true
 
       # - name: Remove existing Python installs # Removes python 3.11.3 and 3.12 to avoid conflict with homebrew python

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -45,8 +45,8 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          brew install pre-commit
-          brew install python@3.9
+          brew tap slalombuild/secureli
+          brew install --only-dependencies secureli
         continue-on-error: true
 
       # - name: Remove existing Python installs # Removes python 3.11.3 and 3.12 to avoid conflict with homebrew python
@@ -74,7 +74,6 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
-          brew tap slalombuild/secureli
           brew install secureli
 
       - name: Checkout test repo

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -41,6 +41,10 @@ jobs:
         run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
       - name: Preinstall Formula Dependencies
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
           brew install \
           pre-commit \
@@ -67,9 +71,13 @@ jobs:
       #     '/usr/local/bin/python3.12-config'
 
       - name: Set up seCureLI
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
           brew tap slalombuild/secureli
-          HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install secureli
+          brew install secureli
 
       - name: Checkout test repo
         uses: actions/checkout@v4

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -47,6 +47,7 @@ jobs:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
           brew install pre-commit
+          brew install python@3.12
           brew install python@3.9
         continue-on-error: true
 

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -44,10 +44,9 @@ jobs:
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
-          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 0
         run: |
           brew install pre-commit
-          brew install python@3.12
           brew install python@3.9
         continue-on-error: true
 

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -44,6 +44,7 @@ jobs:
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
           brew tap slalombuild/secureli
           brew install --only-dependencies secureli

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -50,25 +50,6 @@ jobs:
           brew install --only-dependencies --display-times --verbose secureli
         continue-on-error: true
 
-      # - name: Remove existing Python installs # Removes python 3.11.3 and 3.12 to avoid conflict with homebrew python
-      #   run: |
-      #     rm -rf \
-      #     '/usr/local/bin/2to3' \
-      #     '/usr/local/bin/2to3-3.11' \
-      #     '/usr/local/bin/2to3-3.12' \
-      #     '/usr/local/bin/idle3' \
-      #     '/usr/local/bin/idle3.11' \
-      #     '/usr/local/bin/idle3.12' \
-      #     '/usr/local/bin/pydoc3' \
-      #     '/usr/local/bin/pydoc3.11' \
-      #     '/usr/local/bin/pydoc3.12' \
-      #     '/usr/local/bin/python3' \
-      #     '/usr/local/bin/python3.11' \
-      #     '/usr/local/bin/python3.12' \
-      #     '/usr/local/bin/python3-config' \
-      #     '/usr/local/bin/python3.11-config' \
-      #     '/usr/local/bin/python3.12-config'
-
       - name: Set up seCureLI
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -47,7 +47,7 @@ jobs:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
           brew tap slalombuild/secureli
-          brew install --only-dependencies secureli
+          brew install --only-dependencies --display-times --verbose secureli
         continue-on-error: true
 
       # - name: Remove existing Python installs # Removes python 3.11.3 and 3.12 to avoid conflict with homebrew python
@@ -75,7 +75,7 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
-          brew install secureli
+          brew install --display-times --verbose secureli
 
       - name: Checkout test repo
         uses: actions/checkout@v4

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -40,24 +40,31 @@ jobs:
       - name: Test with Homebrew
         run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-      - name: Remove existing Python installs # Removes python 3.11.3 and 3.12 to avoid conflict with homebrew python
+      - name: Preinstall Formula Dependencies
         run: |
-          rm -rf \
-          '/usr/local/bin/2to3' \
-          '/usr/local/bin/2to3-3.11' \
-          '/usr/local/bin/2to3-3.12' \
-          '/usr/local/bin/idle3' \
-          '/usr/local/bin/idle3.11' \
-          '/usr/local/bin/idle3.12' \
-          '/usr/local/bin/pydoc3' \
-          '/usr/local/bin/pydoc3.11' \
-          '/usr/local/bin/pydoc3.12' \
-          '/usr/local/bin/python3' \
-          '/usr/local/bin/python3.11' \
-          '/usr/local/bin/python3.12' \
-          '/usr/local/bin/python3-config' \
-          '/usr/local/bin/python3.11-config' \
-          '/usr/local/bin/python3.12-config'
+          brew install \
+          pre-commit \
+          python@3.9
+        continue-on-error: true
+
+      # - name: Remove existing Python installs # Removes python 3.11.3 and 3.12 to avoid conflict with homebrew python
+      #   run: |
+      #     rm -rf \
+      #     '/usr/local/bin/2to3' \
+      #     '/usr/local/bin/2to3-3.11' \
+      #     '/usr/local/bin/2to3-3.12' \
+      #     '/usr/local/bin/idle3' \
+      #     '/usr/local/bin/idle3.11' \
+      #     '/usr/local/bin/idle3.12' \
+      #     '/usr/local/bin/pydoc3' \
+      #     '/usr/local/bin/pydoc3.11' \
+      #     '/usr/local/bin/pydoc3.12' \
+      #     '/usr/local/bin/python3' \
+      #     '/usr/local/bin/python3.11' \
+      #     '/usr/local/bin/python3.12' \
+      #     '/usr/local/bin/python3-config' \
+      #     '/usr/local/bin/python3.11-config' \
+      #     '/usr/local/bin/python3.12-config'
 
       - name: Set up seCureLI
         run: |

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -44,7 +44,6 @@ jobs:
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
-          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 0
         run: |
           brew install pre-commit
           brew install python@3.9


### PR DESCRIPTION
This PR has workflow changes to address expected homebrew dependency installation errors during integration testing