### PR TITLE
docs: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+secureli-XXX
+
+<!-- Include general description here -->
+
+
+## Changes
+<!-- A detailed list of changes -->
+*
+
+## Testing
+<!--
+Mention updated tests and any manual testing performed.
+Are aspects not yet tested or not easily testable?
+Feel free to include screenshots if appropriate.
+ -->
+*
+
+## Clean Code Checklist
+<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
+- [ ] Meets acceptance criteria for issue
+- [ ] New logic is covered with automated tests
+- [ ] Appropriate exception handling added
+- [ ] Thoughtful logging included
+- [ ] Documentation is updated
+- [ ] Follow-up work is documented in TODOs
+- [ ] TODOs have a ticket associated with them
+- [ ] No commented-out code included
+
+
+<!--
+Github-flavored markdown reference: https://docs.github.com/en/get-started/writing-on-github
+-->


### PR DESCRIPTION
This should help developers to think about e.g. tests, documentation, etc. when filing a new PR.

I'm open to suggestions on improving this.