### PR TITLE
fix: Fix semantic-release config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,6 @@ build_command = "pip install poetry && poetry build"
 commit_message = "chore(release): Tag v{version} [skip ci]"
 tag_format = "v{version}"
 
-# Enable in a future PR (https://github.com/slalombuild/secureli/issues/250)
-# Consider enabling in pipeline first with no-op option to validate release name
-# [tools.semantic_release.branches.main]
-# prerelease = true
-# prerelease_token = "alpha"
+[tool.semantic_release.branches.main]
+match = "(main|master)"
+prerelease = false  # Toggle to append `-rc.<N>` (e.g. `-rc.1`). Set `prerelease_token` to change suffix


### PR DESCRIPTION
secureli-250

Instead of completing the work that was originally planned for #250 (appending `-A` to our release version), we've opted to not do that but in the process of investigating I found that there was a minor typo in the `pyproject.toml` file that was preventing some of the options from getting picked up correctly.

## Testing

* No new tests were added, but I performed manual testing with a local invocation of `pre-commit version`.
