### PR TITLE
ci: Run BATS test in pipeline 

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,11 +59,15 @@ jobs:
           pip install poetry
           poetry install
 
+      - name: Install BATS for e2e tests
+        uses: bats-core/bats-action@1.5.4
+
       - name: Run Tests
         run: |
           poetry run poe precommit
           poetry run poe coverage
           poetry run secureli build
+          poe e2e
 
 
   secureli-release-noop:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,7 +67,7 @@ jobs:
           poetry run poe precommit
           poetry run poe coverage
           poetry run secureli build
-          poe e2e
+          poetry run poe e2e
 
 
   secureli-release-noop:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -63,6 +63,8 @@ jobs:
         uses: bats-core/bats-action@1.5.4
 
       - name: Run Tests
+        env:
+          BATS_LIBS_ROOT: /usr/lib
         run: |
           poetry run poe precommit
           poetry run poe coverage

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: morrisoncole/pr-lint-action@v1.7.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          title-regex: "(chore|style|test|feat|fix|docs): .+"
+          title-regex: "(chore|style|test|feat|fix|docs|ci): .+"
           on-failed-regex-fail-action: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ install = "poetry install"
 lint = "black --check ."
 precommit = "pre-commit run -a"
 test = ["init", "lint", "coverage_run", "coverage_report"]
-e2e = "bats tests/end-to-end/test.bats"
+e2e = "bats --verbose-run tests/end-to-end/test.bats"
 
 [tool.poetry.dependencies]
 # Until `python-dependency-injector` supports python 3.12, restrict to python 3.11 and lower

--- a/tests/end-to-end/test.bats
+++ b/tests/end-to-end/test.bats
@@ -5,11 +5,11 @@ setup() {
 
 @test "can run secureli init" {
     run python secureli/main.py init -ry
-    assert_output --partial 'seCureLI has not been setup yet.'
-    assert_output --partial 'seCureLI has been installed successfully (language = Python)'
+    assert_output --partial 'Hooks successfully updated to latest version'
+    assert_output --partial 'seCureLI has been installed successfully'
 }
 
 @test "can run secureli scan" {
-    run python secureli/main.py scan -y
-    assert_output --partial 'Scan executed successfully and detected no issues!'
+    run python secureli/main.py scan -y -m all-files
+    assert_output --partial 'Detected the following language(s):'
 }


### PR DESCRIPTION
secureli-128

Running BATS to validate e2e tests on every PR push. They seem to run pretty quickly so it shouldn't add much latency to the pipeline.


## Changes
* BATS tests now run in the pipeline and print out verbose results (This work was done by @joe-stafford )
* Enabling `ci:` as a valid PR prefix, as it's supported by [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Testing
* Fixed existing BATS tests & enabled them in the pipeline

## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [x] Meets acceptance criteria for issue
- [ ] New logic is covered with automated tests
- [ ] Appropriate exception handling added
- [ ] Thoughtful logging included
- [ ] Documentation is updated
- [ ] Follow-up work is documented in TODOs
- [ ] TODOs have a ticket associated with them
- [x] No commented-out code included


<!--
Github-flavored markdown reference: https://docs.github.com/en/get-started/writing-on-github
-->
