### PR TITLE
feat: show versions of configured hooks for repo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,60 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: secureli --version",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/secureli/main.py",
+            "cwd": "${workspaceFolder}",
+            "stopOnEntry": false,
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": ["--version"]
+        },
+        {
+            "name": "Python: secureli --help",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/secureli/main.py",
+            "cwd": "${workspaceFolder}",
+            "stopOnEntry": false,
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": ["--help"]
+        },
+        {
+            "name": "Python: secureli init",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/secureli/main.py",
+            "cwd": "${workspaceFolder}",
+            "stopOnEntry": false,
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": ["init"]
+        },
+        {
+            "name": "Python: secureli scan",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/secureli/main.py",
+            "cwd": "${workspaceFolder}",
+            "stopOnEntry": false,
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": ["scan"]
+        },
+        {
+            "name": "Python: secureli update",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/secureli/main.py",
+            "cwd": "${workspaceFolder}",
+            "stopOnEntry": false,
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": ["update"]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.testing.pytestArgs": ["tests"],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/secureli/main.py
+++ b/secureli/main.py
@@ -10,7 +10,6 @@ from secureli.actions.setup import SetupAction
 from secureli.container import Container
 from secureli.models.echo import Color
 from secureli.models.publish_results import PublishResultsOption
-from secureli.repositories.settings import PreCommitHook
 from secureli.resources import read_resource
 from secureli.settings import Settings
 import secureli.repositories.secureli_config as SecureliConfig

--- a/secureli/main.py
+++ b/secureli/main.py
@@ -28,6 +28,14 @@ container.config.from_pydantic(Settings())
 def version_callback(value: bool):
     if value:
         typer.echo(secureli_version())
+        typer.echo("\nHooks:")
+        config = container.pre_commit_abstraction().get_pre_commit_config(Path("."))
+
+        for repo_config in config.repos:
+            hook_version = f"{repo_config.rev.lstrip('v')}"
+            hooks = ", ".join(hook.id for hook in repo_config.hooks)
+            typer.echo(f"{hook_version:<10} {hooks}")
+
         raise typer.Exit()
 
 


### PR DESCRIPTION
secureli-175

When running `secureli --version` will display the versions of all the pre-commit hooks installed


## Changes
![image](https://github.com/slalombuild/secureli/assets/127901972/f6279aa8-2863-40ba-84e5-f9a1bdddfc96)
<!-- A detailed list of changes -->
* Display list versions of versions of pre-commit hooks installed when running `secureli --version`
* Added launch.json setting file to debug in vscode

## Testing
<!--
Mention updated tests and any manual testing performed.
Are aspects not yet tested or not easily testable?
Feel free to include screenshots if appropriate.
 -->
* All existing unit tests are passing

## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [x] Meets acceptance criteria for issue
- [ ] New logic is covered with automated tests
- [ ] Appropriate exception handling added
- [ ] Thoughtful logging included
- [ ] Documentation is updated
- [ ] Follow-up work is documented in TODOs
- [ ] TODOs have a ticket associated with them
- [x] No commented-out code included


<!--
Github-flavored markdown reference: https://docs.github.com/en/get-started/writing-on-github
-->
