### PR TITLE
fix: set BATS custom paths

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,10 +67,15 @@ jobs:
 
       - name: Install BATS for e2e tests
         uses: bats-core/bats-action@1.5.4
+        with:
+          support-path: ${{ github.workspace }}/bats-core/bats-support
+          assert-path: ${{ github.workspace }}/bats-core/bats-assert
+          detik-path: ${{ github.workspace }}/bats-core/bats-detik
+          file-path: ${{ github.workspace }}/bats-core/bats-file
 
       - name: Run Tests
         env:
-          BATS_LIBS_ROOT: /usr/lib
+          BATS_LIBS_ROOT: ${{ github.workspace }}/bats-core
         run: |
           poetry run poe precommit
           poetry run poe coverage


### PR DESCRIPTION
secureli-420

<!-- Include general description here -->
This PR will fix issues with BATS cache being installed in file area requiring root permission


## Changes
<!-- A detailed list of changes -->
* Update BATS installation file path

## Testing
<!--
Mention updated tests and any manual testing performed.
Are aspects not yet tested or not easily testable?
Feel free to include screenshots if appropriate.
 -->
* No unit testing

## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [X] Meets acceptance criteria for issue
- [X] New logic is covered with automated tests
- [X] Appropriate exception handling added
- [X] Thoughtful logging included
- [X] Documentation is updated
- [X] Follow-up work is documented in TODOs
- [X] TODOs have a ticket associated with them
- [X] No commented-out code included


<!--
Github-flavored markdown reference: https://docs.github.com/en/get-started/writing-on-github
-->
