### PR TITLE
bug: fix secureli version bug in non secureli repo

### DIFF
--- a/secureli/abstractions/pre_commit.py
+++ b/secureli/abstractions/pre_commit.py
@@ -304,3 +304,12 @@ class PreCommitAbstraction:
             contents = f.read()
             yaml_values = yaml.safe_load(contents)
             return PreCommitSettings(**yaml_values)
+
+    def pre_commit_config_exists(self, folder_path: Path) -> bool:
+        """
+        Checks if the .pre-commit-config file exists and returns a boolean
+        :return: boolean - True if config exists and False if not
+        """
+        path_to_config = folder_path / ".pre-commit-config.yaml"
+        path_exists = path_to_config.exists()
+        return path_exists

--- a/secureli/main.py
+++ b/secureli/main.py
@@ -28,20 +28,24 @@ container.config.from_pydantic(Settings())
 def version_callback(value: bool):
     if value:
         typer.echo(secureli_version())
-        typer.echo("\nHook Versions:")
-        typer.echo("--------------")
-        config = container.pre_commit_abstraction().get_pre_commit_config(Path("."))
+        pre_commit_abstr = container.pre_commit_abstraction()
+        path = Path(".")
 
-        all_repos = [
-            (hook.id, repo.rev.lstrip("v"))
-            for repo in config.repos
-            for hook in repo.hooks
-        ]
+        if pre_commit_abstr.pre_commit_config_exists(path):
+            typer.echo("\nHook Versions:")
+            typer.echo("--------------")
+            config = pre_commit_abstr.get_pre_commit_config(path)
 
-        sorted_repos = sorted(all_repos, key=lambda x: x[0])
+            all_repos = [
+                (hook.id, repo.rev.lstrip("v"))
+                for repo in config.repos
+                for hook in repo.hooks
+            ]
 
-        for hook_id, version in sorted_repos:
-            typer.echo(f"{hook_id:<30} {version}")
+            sorted_repos = sorted(all_repos, key=lambda x: x[0])
+
+            for hook_id, version in sorted_repos:
+                typer.echo(f"{hook_id:<30} {version}")
 
         raise typer.Exit()
 

--- a/tests/abstractions/test_pre_commit.py
+++ b/tests/abstractions/test_pre_commit.py
@@ -469,3 +469,15 @@ def test_check_for_hook_updates_returns_repos_with_new_revs(
         assert len(updated_repos) == 1  # only the first repo should be returned
         assert updated_repos[repo_urls[0]].oldRev == "tag1"
         assert updated_repos[repo_urls[0]].newRev == "tag2"
+
+
+def test_pre_commit_config_exists(pre_commit: PreCommitAbstraction):
+    with um.patch.object(Path, "exists", return_value=True):
+        pre_commit_exists = pre_commit.pre_commit_config_exists(test_folder_path)
+        assert pre_commit_exists == True
+
+
+def test_pre_commit_config_does_not_exist(pre_commit: PreCommitAbstraction):
+    with um.patch.object(Path, "exists", return_value=False):
+        pre_commit_exists = pre_commit.pre_commit_config_exists(test_folder_path)
+        assert pre_commit_exists == False


### PR DESCRIPTION
secureli-466

<!-- Include general description here -->
Fix for issue where secureli --version errors out when not run in a repo that has secureli initialized.

## Changes
<!-- A detailed list of changes -->
* Fixed bug

## Testing
<!--
Mention updated tests and any manual testing performed.
Are aspects not yet tested or not easily testable?
Feel free to include screenshots if appropriate.
 -->
* Added unit tests
* All existing unit tests passing

## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [x] Meets acceptance criteria for issue
- [x] New logic is covered with automated tests
- [ ] Appropriate exception handling added
- [ ] Thoughtful logging included
- [ ] Documentation is updated
- [ ] Follow-up work is documented in TODOs
- [ ] TODOs have a ticket associated with them
- [x] No commented-out code included


<!--
Github-flavored markdown reference: https://docs.github.com/en/get-started/writing-on-github
-->
