### PR TITLE
chore: move common service and action models into shared models

### DIFF
--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -1,10 +1,14 @@
 from abc import ABC
-from enum import Enum
 from pathlib import Path
-from typing import Optional
 from secureli.modules.shared.abstractions.echo import EchoAbstraction
 from secureli.modules.observability.consts.logging import TELEMETRY_DEFAULT_ENDPOINT
 from secureli.modules.shared.models.echo import Color
+from secureli.modules.shared.models.install import VerifyOutcome, VerifyResult
+from secureli.modules.shared.models.language import (
+    LanguageMetadata,
+    LanguageNotSupportedError,
+)
+from secureli.modules.shared.models.scan import ScanMode
 from secureli.repositories.secureli_config import (
     SecureliConfig,
     SecureliConfigRepository,
@@ -13,41 +17,14 @@ from secureli.repositories.secureli_config import (
 from secureli.repositories.settings import SecureliRepository, TelemetrySettings
 from secureli.modules.language_analyzer.language_analyzer_services.language_analyzer import (
     LanguageAnalyzerService,
-    AnalyzeResult,
-)
-from secureli.modules.language_analyzer.language_analyzer_services.language_config import (
-    LanguageNotSupportedError,
 )
 from secureli.modules.language_analyzer.language_analyzer_services.language_support import (
-    LanguageMetadata,
     LanguageSupportService,
 )
-from secureli.modules.core.core_services.scanner import ScannerService, ScanMode
+from secureli.modules.core.core_services.scanner import ScannerService
 from secureli.modules.core.core_services.updater import UpdaterService
 
-import pydantic
 from secureli.modules.shared.utilities.formatter import format_sentence_list
-
-
-class VerifyOutcome(str, Enum):
-    INSTALL_CANCELED = "install-canceled"
-    INSTALL_FAILED = "install-failed"
-    INSTALL_SUCCEEDED = "install-succeeded"
-    UPDATE_CANCELED = "update-canceled"
-    UPDATE_SUCCEEDED = "update-succeeded"
-    UPDATE_FAILED = "update-failed"
-    UP_TO_DATE = "up-to-date"
-
-
-class VerifyResult(pydantic.BaseModel):
-    """
-    The outcomes of performing verification. Actions can use these results
-    to decide whether to proceed with their post-initialization actions or not.
-    """
-
-    outcome: VerifyOutcome
-    config: Optional[SecureliConfig] = None
-    analyze_result: Optional[AnalyzeResult] = None
 
 
 class ActionDependencies:

--- a/secureli/actions/build.py
+++ b/secureli/actions/build.py
@@ -1,8 +1,8 @@
 from secureli.modules.shared.abstractions.echo import EchoAbstraction, Color
 from secureli.modules.observability.observability_services.logging import (
     LoggingService,
-    LogAction,
 )
+from secureli.modules.shared.models.logging import LogAction
 
 
 class BuildAction:

--- a/secureli/actions/initializer.py
+++ b/secureli/actions/initializer.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 
 from secureli.actions.scan import ScanAction
-from secureli.actions.action import Action, ActionDependencies, VerifyResult
+from secureli.actions.action import Action, ActionDependencies
 from secureli.modules.observability.observability_services.logging import (
     LoggingService,
-    LogAction,
 )
+from secureli.modules.shared.models.install import VerifyResult
+from secureli.modules.shared.models.logging import LogAction
 
 
 class InitializerAction(Action):

--- a/secureli/actions/scan.py
+++ b/secureli/actions/scan.py
@@ -6,22 +6,21 @@ from typing import Optional
 
 from secureli.modules.shared.abstractions.echo import EchoAbstraction
 from secureli.actions.action import (
-    VerifyOutcome,
     Action,
     ActionDependencies,
-    VerifyResult,
 )
 from secureli.modules.shared.models.exit_codes import ExitCode
+from secureli.modules.shared.models.install import VerifyOutcome, VerifyResult
+from secureli.modules.shared.models.logging import LogAction
 from secureli.modules.shared.models.publish_results import PublishResultsOption
 from secureli.modules.shared.models.result import Result
 from secureli.modules.observability.observability_services.logging import (
     LoggingService,
-    LogAction,
 )
 from secureli.modules.core.core_services.scanner import (
-    ScanMode,
     ScannerService,
 )
+from secureli.modules.shared.models.scan import ScanMode
 from secureli.settings import Settings
 from secureli.modules.shared.utilities.usage_stats import (
     post_log,

--- a/secureli/actions/setup.py
+++ b/secureli/actions/setup.py
@@ -1,6 +1,6 @@
 import jinja2
 
-from secureli.modules.language_analyzer.language_analyzer_services.language_support import (
+from secureli.modules.shared.consts.language import (
     supported_languages,
 )
 

--- a/secureli/actions/update.py
+++ b/secureli/actions/update.py
@@ -3,12 +3,13 @@ from pathlib import Path
 from secureli.modules.shared.abstractions.echo import EchoAbstraction
 from secureli.modules.observability.observability_services.logging import (
     LoggingService,
-    LogAction,
 )
 from secureli.modules.core.core_services.updater import UpdaterService
 from secureli.actions.action import Action, ActionDependencies
 
 from rich.progress import Progress
+
+from secureli.modules.shared.models.logging import LogAction
 
 
 class UpdateAction(Action):

--- a/secureli/main.py
+++ b/secureli/main.py
@@ -3,13 +3,13 @@ from typing import Optional, List
 from typing_extensions import Annotated
 import typer
 from typer import Option
-from secureli.actions.action import VerifyOutcome
 
-from secureli.actions.scan import ScanMode
 from secureli.actions.setup import SetupAction
 from secureli.container import Container
 from secureli.modules.shared.models.echo import Color
+from secureli.modules.shared.models.install import VerifyOutcome
 from secureli.modules.shared.models.publish_results import PublishResultsOption
+from secureli.modules.shared.models.scan import ScanMode
 from secureli.modules.shared.resources import read_resource
 from secureli.settings import Settings
 import secureli.repositories.secureli_config as SecureliConfig

--- a/secureli/modules/core/core_services/scanner.py
+++ b/secureli/modules/core/core_services/scanner.py
@@ -6,16 +6,8 @@ import pydantic
 import re
 
 from secureli.modules.shared.abstractions.pre_commit import PreCommitAbstraction
+from secureli.modules.shared.models.scan import ScanFailure, ScanMode, ScanResult
 from secureli.repositories.settings import PreCommitSettings
-
-
-class ScanMode(str, Enum):
-    """
-    Which scan mode to run as when we perform scanning.
-    """
-
-    STAGED_ONLY = "staged-only"
-    ALL_FILES = "all-files"
 
 
 class OutputParseErrors(str, Enum):
@@ -26,32 +18,12 @@ class OutputParseErrors(str, Enum):
     REPO_NOT_FOUND = "repo-not-found"
 
 
-class Failure(pydantic.BaseModel):
-    """
-    Represents the details of a failed rule from a scan
-    """
-
-    repo: str
-    id: str
-    file: str
-
-
-class ScanResult(pydantic.BaseModel):
-    """
-    The results of calling scan_repo
-    """
-
-    successful: bool
-    output: Optional[str] = None
-    failures: list[Failure]
-
-
 class ScanOuput(pydantic.BaseModel):
     """
     Represents the parsed output from a scan
     """
 
-    failures: list[Failure]
+    failures: list[ScanFailure]
 
 
 class ScannerService:
@@ -128,7 +100,7 @@ class ScannerService:
             files = self._find_file_names(failure_output_list=failure_output_list)
 
             for file in files:
-                failures.append(Failure(id=id, file=file, repo=repo))
+                failures.append(ScanFailure(id=id, file=file, repo=repo))
 
         return ScanOuput(failures=failures)
 

--- a/secureli/modules/language_analyzer/language_analyzer_services/language_analyzer.py
+++ b/secureli/modules/language_analyzer/language_analyzer_services/language_analyzer.py
@@ -1,31 +1,12 @@
 from collections import defaultdict
 from pathlib import Path
 
-import pydantic
-
 from secureli.modules.shared.abstractions.lexer_guesser import LexerGuesser
+from secureli.modules.shared.models.language import AnalyzeResult, SkippedFile
 from secureli.repositories.repo_files import RepoFilesRepository
-from secureli.modules.language_analyzer.language_analyzer_services.language_support import (
+from secureli.modules.shared.consts.language import (
     supported_languages,
 )
-
-
-class SkippedFile(pydantic.BaseModel):
-    """
-    A file skipped by the analysis phase.
-    """
-
-    file_path: Path
-    error_message: str
-
-
-class AnalyzeResult(pydantic.BaseModel):
-    """
-    The result of the analysis phase.
-    """
-
-    language_proportions: dict[str, float]
-    skipped_files: list[SkippedFile]
 
 
 class LanguageAnalyzerService:

--- a/secureli/modules/language_analyzer/language_analyzer_services/language_config.py
+++ b/secureli/modules/language_analyzer/language_analyzer_services/language_config.py
@@ -1,36 +1,15 @@
 from pathlib import Path
-from typing import Callable, Any
-
-import pydantic
+from typing import Callable
 import yaml
 
+from secureli.modules.shared.models.language import (
+    LanguageNotSupportedError,
+    LanguagePreCommitResult,
+    LoadLinterConfigsResult,
+)
 from secureli.modules.shared.resources.slugify import slugify
 from secureli.modules.shared.utilities.hash import hash_config
 from secureli.modules.shared.utilities.patterns import combine_patterns
-
-
-class LanguageNotSupportedError(Exception):
-    """The given language was not supported by the PreCommitHooks abstraction"""
-
-    pass
-
-
-class LoadLinterConfigsResult(pydantic.BaseModel):
-    """Results from finding and loading any pre-commit configs for the language"""
-
-    successful: bool
-    linter_data: list[Any]
-
-
-class LanguagePreCommitResult(pydantic.BaseModel):
-    """
-    A configuration model for a supported pre-commit-configurable language.
-    """
-
-    language: str
-    config_data: str
-    version: str
-    linter_config: LoadLinterConfigsResult
 
 
 class LanguageConfigService:

--- a/secureli/modules/language_analyzer/language_analyzer_services/language_support.py
+++ b/secureli/modules/language_analyzer/language_analyzer_services/language_support.py
@@ -3,7 +3,8 @@ from typing import Callable, Iterable, Optional, Any
 
 import pydantic
 import yaml
-from secureli.modules.shared.abstractions.echo import EchoAbstraction
+from secureli.modules.shared.models.config import HookConfiguration, LinterConfig, Repo
+from secureli.modules.shared.models.language import LanguageMetadata
 
 import secureli.repositories.secureli_config as SecureliConfig
 from secureli.modules.shared.abstractions.pre_commit import PreCommitAbstraction
@@ -15,70 +16,6 @@ from secureli.modules.language_analyzer.language_analyzer_services.language_conf
     LanguageConfigService,
 )
 from secureli.modules.shared.utilities.hash import hash_config
-
-supported_languages = [
-    "C#",
-    "Python",
-    "Java",
-    "Terraform",
-    "TypeScript",
-    "JavaScript",
-    "Go",
-    "Swift",
-    "Kotlin",
-]
-
-
-class LanguageMetadata(pydantic.BaseModel):
-    version: str
-    security_hook_id: Optional[str]
-    linter_config_write_errors: Optional[list[str]] = []
-
-
-class ValidateConfigResult(pydantic.BaseModel):
-    """
-    The results of calling validate_config
-    """
-
-    successful: bool
-    output: str
-
-
-class Repo(pydantic.BaseModel):
-    """A repository containing pre-commit hooks"""
-
-    repo: str
-    revision: str
-    hooks: list[str]
-
-
-class HookConfiguration(pydantic.BaseModel):
-    """A simplified pre-commit configuration representation for logging purposes"""
-
-    repos: list[Repo]
-
-
-class UnexpectedReposResult(pydantic.BaseModel):
-    """
-    The result of checking for unexpected repos in config
-    """
-
-    missing_repos: Optional[list[str]] = []
-    unexpected_repos: Optional[list[str]] = []
-
-
-class LinterConfigData(pydantic.BaseModel):
-    """
-    Represents the structure of a linter config file
-    """
-
-    filename: str
-    settings: Any
-
-
-class LinterConfig(pydantic.BaseModel):
-    language: str
-    linter_data: list[LinterConfigData]
 
 
 class BuildConfigResult(pydantic.BaseModel):

--- a/secureli/modules/observability/observability_services/logging.py
+++ b/secureli/modules/observability/observability_services/logging.py
@@ -6,11 +6,12 @@ from typing import Optional
 from uuid import uuid4
 
 import pydantic
+from secureli.modules.shared.models.config import HookConfiguration
+from secureli.modules.shared.models.logging import LogAction
 
 import secureli.repositories.secureli_config as SecureliConfig
 from secureli.modules.language_analyzer.language_analyzer_services.language_support import (
     LanguageSupportService,
-    HookConfiguration,
 )
 from secureli.repositories.secureli_config import SecureliConfigRepository
 from secureli.modules.shared.utilities.git_meta import (
@@ -35,16 +36,6 @@ class LogStatus(str, Enum):
 
     success = "SUCCESS"
     failure = "FAILURE"
-
-
-class LogAction(str, Enum):
-    """Which action the log entry is associated with"""
-
-    scan = "SCAN"
-    init = "INIT"
-    build = "_BUILD"
-    update = "UPDATE"
-    publish = "PUBLISH"  # "PUBLISH" does not correspond to a CLI action/subcommand
 
 
 class LogFailure(pydantic.BaseModel):

--- a/secureli/modules/shared/consts/language.py
+++ b/secureli/modules/shared/consts/language.py
@@ -1,0 +1,11 @@
+supported_languages = [
+    "C#",
+    "Python",
+    "Java",
+    "Terraform",
+    "TypeScript",
+    "JavaScript",
+    "Go",
+    "Swift",
+    "Kotlin",
+]

--- a/secureli/modules/shared/models/config.py
+++ b/secureli/modules/shared/models/config.py
@@ -1,0 +1,30 @@
+from typing import Any
+import pydantic
+
+
+class Repo(pydantic.BaseModel):
+    """A repository containing pre-commit hooks"""
+
+    repo: str
+    revision: str
+    hooks: list[str]
+
+
+class HookConfiguration(pydantic.BaseModel):
+    """A simplified pre-commit configuration representation for logging purposes"""
+
+    repos: list[Repo]
+
+
+class LinterConfigData(pydantic.BaseModel):
+    """
+    Represents the structure of a linter config file
+    """
+
+    filename: str
+    settings: Any
+
+
+class LinterConfig(pydantic.BaseModel):
+    language: str
+    linter_data: list[LinterConfigData]

--- a/secureli/modules/shared/models/install.py
+++ b/secureli/modules/shared/models/install.py
@@ -1,0 +1,28 @@
+from enum import Enum
+from typing import Optional
+
+import pydantic
+from secureli.modules.shared.models.language import AnalyzeResult
+
+from secureli.repositories.secureli_config import SecureliConfig
+
+
+class VerifyOutcome(str, Enum):
+    INSTALL_CANCELED = "install-canceled"
+    INSTALL_FAILED = "install-failed"
+    INSTALL_SUCCEEDED = "install-succeeded"
+    UPDATE_CANCELED = "update-canceled"
+    UPDATE_SUCCEEDED = "update-succeeded"
+    UPDATE_FAILED = "update-failed"
+    UP_TO_DATE = "up-to-date"
+
+
+class VerifyResult(pydantic.BaseModel):
+    """
+    The outcomes of performing verification. Actions can use these results
+    to decide whether to proceed with their post-initialization actions or not.
+    """
+
+    outcome: VerifyOutcome
+    config: Optional[SecureliConfig] = None
+    analyze_result: Optional[AnalyzeResult] = None

--- a/secureli/modules/shared/models/language.py
+++ b/secureli/modules/shared/models/language.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from typing import Any, Optional
+import pydantic
+
+from secureli.modules.shared.models.config import LinterConfig
+
+
+class SkippedFile(pydantic.BaseModel):
+    """
+    A file skipped by the analysis phase.
+    """
+
+    file_path: Path
+    error_message: str
+
+
+class AnalyzeResult(pydantic.BaseModel):
+    """
+    The result of the analysis phase.
+    """
+
+    language_proportions: dict[str, float]
+    skipped_files: list[SkippedFile]
+
+
+class LanguageNotSupportedError(Exception):
+    """The given language was not supported by the PreCommitHooks abstraction"""
+
+    pass
+
+
+class LoadLinterConfigsResult(pydantic.BaseModel):
+    """Results from finding and loading any pre-commit configs for the language"""
+
+    successful: bool
+    linter_data: list[Any]
+
+
+class LanguagePreCommitResult(pydantic.BaseModel):
+    """
+    A configuration model for a supported pre-commit-configurable language.
+    """
+
+    language: str
+    config_data: str
+    version: str
+    linter_config: LoadLinterConfigsResult
+
+
+class LanguageMetadata(pydantic.BaseModel):
+    version: str
+    security_hook_id: Optional[str]
+    linter_config_write_errors: Optional[list[str]] = []

--- a/secureli/modules/shared/models/logging.py
+++ b/secureli/modules/shared/models/logging.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class LogAction(str, Enum):
+    """Which action the log entry is associated with"""
+
+    scan = "SCAN"
+    init = "INIT"
+    build = "_BUILD"
+    update = "UPDATE"
+    publish = "PUBLISH"  # "PUBLISH" does not correspond to a CLI action/subcommand

--- a/secureli/modules/shared/models/scan.py
+++ b/secureli/modules/shared/models/scan.py
@@ -1,0 +1,33 @@
+from enum import Enum
+from typing import Optional
+
+import pydantic
+
+
+class ScanMode(str, Enum):
+    """
+    Which scan mode to run as when we perform scanning.
+    """
+
+    STAGED_ONLY = "staged-only"
+    ALL_FILES = "all-files"
+
+
+class ScanFailure(pydantic.BaseModel):
+    """
+    Represents the details of a failed rule from a scan
+    """
+
+    repo: str
+    id: str
+    file: str
+
+
+class ScanResult(pydantic.BaseModel):
+    """
+    The results of calling scan_repo
+    """
+
+    successful: bool
+    output: Optional[str] = None
+    failures: list[ScanFailure]

--- a/secureli/modules/shared/utilities/usage_stats.py
+++ b/secureli/modules/shared/utilities/usage_stats.py
@@ -6,14 +6,13 @@ from secureli.modules.observability.consts.logging import (
 )
 from secureli.modules.shared.models.publish_results import PublishLogResult
 from secureli.modules.shared.models.result import Result
-
-from secureli.modules.core.core_services.scanner import Failure
 from collections import Counter
+from secureli.modules.shared.models.scan import ScanFailure
 
 from secureli.settings import Settings
 
 
-def convert_failures_to_failure_count(failure_list: list[Failure]):
+def convert_failures_to_failure_count(failure_list: list[ScanFailure]):
     """
     Convert a list of Failure ids to a list of individual failure count with underscore naming convention
     :param failure_list: a list of Failure Object

--- a/tests/actions/conftest.py
+++ b/tests/actions/conftest.py
@@ -2,12 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from secureli.modules.language_analyzer.language_analyzer_services.language_analyzer import (
-    AnalyzeResult,
-)
-from secureli.modules.language_analyzer.language_analyzer_services.language_support import (
-    LanguageMetadata,
-)
+from secureli.modules.shared.models.language import AnalyzeResult, LanguageMetadata
 
 
 # Register generic mocks you'd like available for every test.

--- a/tests/actions/test_action.py
+++ b/tests/actions/test_action.py
@@ -4,20 +4,18 @@ from unittest.mock import MagicMock
 import pytest
 from secureli.modules.shared.abstractions.pre_commit import InstallResult
 
-from secureli.actions.action import Action, ActionDependencies, VerifyOutcome
+from secureli.actions.action import Action, ActionDependencies
 from secureli.modules.observability.consts.logging import TELEMETRY_DEFAULT_ENDPOINT
 from secureli.modules.shared.models.echo import Color
-from secureli.repositories.secureli_config import SecureliConfig, VerifyConfigOutcome
-from secureli.modules.language_analyzer.language_analyzer_services.language_analyzer import (
+from secureli.modules.shared.models.install import VerifyOutcome
+from secureli.modules.shared.models.language import (
     AnalyzeResult,
+    LanguageMetadata,
     SkippedFile,
 )
-from secureli.modules.language_analyzer.language_analyzer_services.language_support import (
-    LanguageMetadata,
-)
-from secureli.modules.core.core_services.scanner import ScanResult, Failure
+from secureli.modules.shared.models.scan import ScanFailure, ScanResult
+from secureli.repositories.secureli_config import SecureliConfig, VerifyConfigOutcome
 from secureli.modules.core.core_services.updater import UpdateResult
-from secureli.settings import Settings
 
 test_folder_path = Path("does-not-matter")
 
@@ -122,7 +120,7 @@ def test_that_initialize_repo_install_flow_displays_security_analysis_results(
     mock_scanner.scan_repo.return_value = ScanResult(
         successful=False,
         output="Detect secrets...Failed",
-        failures=[Failure(repo="repo", id="id", file="file")],
+        failures=[ScanFailure(repo="repo", id="id", file="file")],
     )
     action.verify_install(test_folder_path, reset=True, always_yes=True)
 

--- a/tests/actions/test_initializer_action.py
+++ b/tests/actions/test_initializer_action.py
@@ -5,13 +5,8 @@ import pytest
 
 from secureli.actions.action import ActionDependencies
 from secureli.actions.initializer import InitializerAction
-from secureli.repositories.secureli_config import SecureliConfig
-from secureli.repositories.settings import SecureliFile, TelemetrySettings
-from secureli.modules.language_analyzer.language_analyzer_services.language_config import (
-    LanguageNotSupportedError,
-)
-from secureli.modules.observability.observability_services.logging import LogAction
-from secureli.settings import Settings
+from secureli.modules.shared.models.language import LanguageNotSupportedError
+from secureli.modules.shared.models.logging import LogAction
 
 test_folder_path = Path("does-not-matter")
 

--- a/tests/actions/test_scan_action.py
+++ b/tests/actions/test_scan_action.py
@@ -1,10 +1,14 @@
 from pathlib import Path
 from secureli.modules.shared.abstractions.pre_commit import RevisionPair
-from secureli.actions.action import ActionDependencies, VerifyOutcome
+from secureli.actions.action import ActionDependencies
 from secureli.actions.scan import ScanAction
 from secureli.modules.shared.models.exit_codes import ExitCode
+from secureli.modules.shared.models.install import VerifyOutcome
+from secureli.modules.shared.models.language import AnalyzeResult
+from secureli.modules.shared.models.logging import LogAction
 from secureli.modules.shared.models.publish_results import PublishResultsOption
 from secureli.modules.shared.models.result import Result
+from secureli.modules.shared.models.scan import ScanMode, ScanResult
 from secureli.repositories.secureli_config import SecureliConfig, VerifyConfigOutcome
 from secureli.repositories.settings import (
     PreCommitHook,
@@ -14,11 +18,6 @@ from secureli.repositories.settings import (
     EchoSettings,
     EchoLevel,
 )
-from secureli.modules.language_analyzer.language_analyzer_services.language_analyzer import (
-    AnalyzeResult,
-)
-from secureli.modules.observability.observability_services.logging import LogAction
-from secureli.modules.core.core_services.scanner import ScanMode, ScanResult
 from unittest import mock
 from unittest.mock import MagicMock
 from pytest_mock import MockerFixture

--- a/tests/application/test_main.py
+++ b/tests/application/test_main.py
@@ -4,12 +4,12 @@ from typer.testing import CliRunner
 
 import pytest
 from pytest_mock import MockerFixture
-from secureli.actions.action import VerifyOutcome, VerifyResult
 
 import secureli.container
 import secureli.main
+from secureli.modules.shared.models.install import VerifyOutcome, VerifyResult
 from secureli.modules.shared.models.publish_results import PublishResultsOption
-from secureli.modules.core.core_services.scanner import ScanMode
+from secureli.modules.shared.models.scan import ScanMode
 from secureli.modules.shared.utilities.secureli_meta import secureli_version
 
 

--- a/tests/modules/core/test_scanner_service.py
+++ b/tests/modules/core/test_scanner_service.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from secureli.modules.shared.abstractions.pre_commit import ExecuteResult
+from secureli.modules.shared.models.scan import ScanMode
 from secureli.repositories.settings import (
     PreCommitHook,
     PreCommitRepo,
@@ -10,7 +11,6 @@ from secureli.repositories.settings import (
 )
 from secureli.modules.core.core_services.scanner import (
     ScannerService,
-    ScanMode,
     OutputParseErrors,
 )
 from pytest_mock import MockerFixture

--- a/tests/modules/language_analyzer/test_language_config.py
+++ b/tests/modules/language_analyzer/test_language_config.py
@@ -4,6 +4,8 @@ import pytest
 
 from secureli.modules.language_analyzer.language_analyzer_services.language_config import (
     LanguageConfigService,
+)
+from secureli.modules.shared.models.language import (
     LanguageNotSupportedError,
     LoadLinterConfigsResult,
 )

--- a/tests/modules/language_analyzer/test_language_support.py
+++ b/tests/modules/language_analyzer/test_language_support.py
@@ -9,12 +9,13 @@ from secureli.modules.shared.abstractions.pre_commit import (
 )
 from secureli.modules.language_analyzer.language_analyzer_services.language_support import (
     LanguageSupportService,
-    LinterConfig,
-    LinterConfigData,
     LinterConfigWriteResult,
 )
 from secureli.modules.language_analyzer.language_analyzer_services.language_config import (
     LanguageConfigService,
+)
+from secureli.modules.shared.models.config import LinterConfig, LinterConfigData
+from secureli.modules.shared.models.language import (
     LanguagePreCommitResult,
     LoadLinterConfigsResult,
 )

--- a/tests/modules/observability/test_logging_service.py
+++ b/tests/modules/observability/test_logging_service.py
@@ -3,14 +3,12 @@ from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
+from secureli.modules.shared.models.config import HookConfiguration
+from secureli.modules.shared.models.logging import LogAction
 
 from secureli.repositories.secureli_config import SecureliConfig
 from secureli.modules.observability.observability_services.logging import (
     LoggingService,
-    LogAction,
-)
-from secureli.modules.language_analyzer.language_analyzer_services.language_support import (
-    HookConfiguration,
 )
 
 

--- a/tests/modules/shared/utilities/test_usage_stats.py
+++ b/tests/modules/shared/utilities/test_usage_stats.py
@@ -4,13 +4,13 @@ from secureli.modules.observability.consts.logging import (
 )
 from secureli.modules.shared.models.publish_results import PublishLogResult
 from secureli.modules.shared.models.result import Result
+from secureli.modules.shared.models.scan import ScanFailure
 from secureli.repositories.settings import TelemetrySettings
 from secureli.settings import Settings
 from secureli.modules.shared.utilities.usage_stats import (
     post_log,
     convert_failures_to_failure_count,
 )
-from secureli.modules.core.core_services.scanner import Failure
 from unittest import mock
 from unittest.mock import Mock, patch
 
@@ -19,9 +19,9 @@ import os
 
 def test_that_convert_failures_to_failure_count_returns_correct_count():
     list_of_failure = [
-        Failure(id="testfailid1", file="testfile1", repo="testrepo1"),
-        Failure(id="testfailid1", file="testfile2", repo="testrepo1"),
-        Failure(id="testfailid2", file="testfile1", repo="testrepo1"),
+        ScanFailure(id="testfailid1", file="testfile1", repo="testrepo1"),
+        ScanFailure(id="testfailid1", file="testfile2", repo="testrepo1"),
+        ScanFailure(id="testfailid2", file="testfile1", repo="testrepo1"),
     ]
 
     result = convert_failures_to_failure_count(list_of_failure)


### PR DESCRIPTION
secureli-441
secureli-442

<!-- Include general description here -->
closes #441 #442

Moves commonly used action and service models into shared models folder

## Changes
<!-- A detailed list of changes -->
* Move action models
* Move service models
* Remove unused action+service models

## Testing
<!--
Mention updated tests and any manual testing performed.
Are aspects not yet tested or not easily testable?
Feel free to include screenshots if appropriate.
 -->
*

## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [ ] Meets acceptance criteria for issue
- [ ] New logic is covered with automated tests
- [ ] Appropriate exception handling added
- [ ] Thoughtful logging included
- [ ] Documentation is updated
- [ ] Follow-up work is documented in TODOs
- [ ] TODOs have a ticket associated with them
- [ ] No commented-out code included


<!--
Github-flavored markdown reference: https://docs.github.com/en/get-started/writing-on-github
-->
