### PR TITLE
Feat: secureli 372 fix init when no pre-commit-config exists

### DIFF
--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -101,7 +101,7 @@ class Action(ABC):
 
             if update_result.outcome != VerifyOutcome.UPDATE_SUCCEEDED:
                 self.action_deps.echo.error(
-                    "seCureLI pre-commit-config.yaml could not be updated."
+                    "seCureLI .pre-commit-config.yaml could not be moved."
                 )
                 return update_result
             else:

--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -60,7 +60,6 @@ class Action(ABC):
         reset: bool,
         always_yes: bool,
         files: list[Path],
-        is_retry: bool = False,
     ) -> VerifyResult:
         """
         Installs, upgrades or verifies the current seCureLI installation
@@ -146,11 +145,7 @@ class Action(ABC):
                 languages,
                 newly_detected_languages,
                 always_yes,
-                pre_commit_config_location=(
-                    preferred_config_path
-                    if pre_commit_config_location_is_correct
-                    else None
-                ),
+                preferred_config_path,
             )
         else:
             self.action_deps.echo.print(

--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -85,13 +85,13 @@ class Action(ABC):
         preferred_config_path = self.action_deps.hooks_scanner.pre_commit.get_preferred_pre_commit_config_path(
             folder_path
         )
-
-        if (
+        pre_commit_to_preserve = (
             self.action_deps.hooks_scanner.pre_commit.pre_commit_config_exists(
                 folder_path
             )
             and not pre_commit_config_location_is_correct
-        ):
+        )
+        if pre_commit_to_preserve:
             update_result: VerifyResult = (
                 self._update_secureli_pre_commit_config_location(
                     folder_path, always_yes
@@ -105,11 +105,6 @@ class Action(ABC):
                 return update_result
             else:
                 preferred_config_path = update_result.file_path
-        elif not preferred_config_path.exists():
-            self.action_deps.echo.warning(
-                "No pre-commit-config was found, creating new config."
-            )
-            open(preferred_config_path, "w")
 
         config = self.get_secureli_config(reset=reset)
         languages = []
@@ -145,7 +140,7 @@ class Action(ABC):
                 languages,
                 newly_detected_languages,
                 always_yes,
-                preferred_config_path,
+                preferred_config_path if pre_commit_to_preserve else None,
             )
         else:
             self.action_deps.echo.print(
@@ -178,7 +173,7 @@ class Action(ABC):
 
         # pre-install
         new_install = len(detected_languages) == len(install_languages)
-
+        self.action_deps.echo.print(f"BINGOOOOOOO, {new_install}")
         should_install = self._prompt_to_install(
             install_languages, always_yes, new_install
         )

--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -173,7 +173,6 @@ class Action(ABC):
 
         # pre-install
         new_install = len(detected_languages) == len(install_languages)
-        self.action_deps.echo.print(f"BINGOOOOOOO, {new_install}")
         should_install = self._prompt_to_install(
             install_languages, always_yes, new_install
         )

--- a/secureli/modules/language_analyzer/language_support.py
+++ b/secureli/modules/language_analyzer/language_support.py
@@ -156,7 +156,8 @@ class LanguageSupportService:
                 try:
                     data = yaml.safe_load(stream)
                     existing_data = data or {}
-                    config_repos += data["repos"]
+                    config_repos += data.get("repos")
+
                 except yaml.YAMLError:
                     self.echo.error(
                         f"There was an issue parsing existing pre-commit-config.yaml."
@@ -187,7 +188,7 @@ class LanguageSupportService:
                     else None
                 )
                 data = yaml.safe_load(result.config_data)
-                config_repos += data["repos"] or []
+                config_repos += data.get("repos") or []
 
         config = {**existing_data, "repos": config_repos}
         version = hash_config(yaml.dump(config))

--- a/secureli/modules/language_analyzer/language_support.py
+++ b/secureli/modules/language_analyzer/language_support.py
@@ -158,7 +158,7 @@ class LanguageSupportService:
                 try:
                     data = yaml.safe_load(stream)
                     existing_data = data or {}
-                    config_repos += data["repos"] if data else []
+                    config_repos += data["repos"] if data and data.get("repos") else []
 
                 except yaml.YAMLError:
                     self.echo.error(

--- a/secureli/modules/language_analyzer/language_support.py
+++ b/secureli/modules/language_analyzer/language_support.py
@@ -48,8 +48,10 @@ class LanguageSupportService:
         as well as a secret-detection hook ID, if present.
         """
 
-        path_to_pre_commit_file: Path = self.pre_commit_hook.get_pre_commit_config_path(
-            SecureliConfig.FOLDER_PATH
+        path_to_pre_commit_file: Path = (
+            self.pre_commit_hook.get_preferred_pre_commit_config_path(
+                SecureliConfig.FOLDER_PATH
+            )
         )
 
         linter_config_write_result = self._write_pre_commit_configs(
@@ -156,7 +158,7 @@ class LanguageSupportService:
                 try:
                     data = yaml.safe_load(stream)
                     existing_data = data or {}
-                    config_repos += data.get("repos")
+                    config_repos += data["repos"] if data else []
 
                 except yaml.YAMLError:
                     self.echo.error(
@@ -188,7 +190,7 @@ class LanguageSupportService:
                     else None
                 )
                 data = yaml.safe_load(result.config_data)
-                config_repos += data.get("repos") or []
+                config_repos += data["repos"] or []
 
         config = {**existing_data, "repos": config_repos}
         version = hash_config(yaml.dump(config))

--- a/secureli/modules/shared/abstractions/pre_commit.py
+++ b/secureli/modules/shared/abstractions/pre_commit.py
@@ -378,7 +378,7 @@ class PreCommitAbstraction:
         Feel free to delete this method after an appropriate period of time (a few months?)
         """
         existing_config_file_path = self.get_pre_commit_config_path(folder_path)
-        new_config_file_path = folder_path / ".secureli" / self.CONFIG_FILE_NAME
+        new_config_file_path = self.get_preferred_pre_commit_config_path(folder_path)
         self.echo.print(
             f"Moving {existing_config_file_path} to {new_config_file_path}..."
         )

--- a/secureli/modules/shared/abstractions/pre_commit.py
+++ b/secureli/modules/shared/abstractions/pre_commit.py
@@ -344,6 +344,18 @@ class PreCommitAbstraction:
                 f"Could not find pre-commit hooks in .secureli/{self.CONFIG_FILE_NAME}"
             )
 
+    def get_pre_commit_config_path_is_correct(self, folder_path: Path) -> bool:
+        """Returns whether a pre-commit-config exists in a given folder path"""
+        preferred_pre_commit_config_location = (
+            self.get_preferred_pre_commit_config_path(folder_path)
+        )
+        pre_commit_config_path = folder_path / self.CONFIG_FILE_NAME
+        return (
+            preferred_pre_commit_config_location.exists()
+            or pre_commit_config_path.exists()
+            and pre_commit_config_path == preferred_pre_commit_config_location
+        )
+
     def get_pre_commit_config(self, folder_path: Path):
         """
         Gets the contents of the .pre-commit-config file and returns it as a dictionary

--- a/tests/actions/test_action.py
+++ b/tests/actions/test_action.py
@@ -438,7 +438,7 @@ def test_that_verify_install_returns_failure_result_without_pre_commit_config_fi
             test_folder_path, reset=False, always_yes=True, files=None
         )
         mock_echo.error.assert_called_once_with(
-            "seCureLI pre-commit-config.yaml could not be updated."
+            "seCureLI .pre-commit-config.yaml could not be moved."
         )
         assert verify_result.outcome == VerifyOutcome.UPDATE_FAILED
 

--- a/tests/actions/test_action.py
+++ b/tests/actions/test_action.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, mock_open
 
 import pytest
 from secureli.modules.shared.abstractions.pre_commit import InstallResult
@@ -181,12 +181,18 @@ def test_that_initialize_repo_install_flow_warns_about_skipped_files(
 def test_that_initialize_repo_can_be_canceled(
     action: Action,
     mock_echo: MagicMock,
+    mock_hooks_scanner: MagicMock,
 ):
     mock_echo.confirm.return_value = False
+    mock_hooks_scanner.pre_commit.get_pre_commit_config_path_is_correct.return_value = (
+        True
+    )
+    with (patch.object(Path, "exists", return_value=True),):
+        action.verify_install(
+            test_folder_path, reset=True, always_yes=False, files=None
+        )
 
-    action.verify_install(test_folder_path, reset=True, always_yes=False, files=None)
-
-    mock_echo.error.assert_called_with("User canceled install process")
+        mock_echo.error.assert_called_with("User canceled install process")
 
 
 def test_that_initialize_repo_selects_previously_selected_language(
@@ -411,18 +417,23 @@ def test_that_verify_install_returns_success_result_newly_detected_language_inst
     assert verify_result.outcome == VerifyOutcome.INSTALL_SUCCEEDED
 
 
-def test_that_verify_install_returns_failure_result_without_re_commit_config_file_path(
+def test_that_verify_install_returns_failure_result_without_pre_commit_config_file_path(
     action: Action,
     mock_hooks_scanner: MagicMock,
     mock_echo: MagicMock,
 ):
+
     with (patch.object(Path, "exists", return_value=False),):
         mock_hooks_scanner.pre_commit.get_preferred_pre_commit_config_path.return_value = (
             test_folder_path / ".secureli" / ".pre-commit-config.yaml"
         )
+        mock_hooks_scanner.pre_commit.get_pre_commit_config_path_is_correct.return_value = (
+            False
+        )
         mock_hooks_scanner.pre_commit.migrate_config_file.side_effect = Exception(
             "ERROR"
         )
+
         verify_result = action.verify_install(
             test_folder_path, reset=False, always_yes=True, files=None
         )
@@ -437,13 +448,39 @@ def test_that_verify_install_continues_after_pre_commit_config_file_moved(
     mock_hooks_scanner: MagicMock,
     mock_echo: MagicMock,
 ):
-    with (patch.object(Path, "exists", return_value=False),):
+    with (patch.object(Path, "exists", return_value=True),):
         mock_hooks_scanner.pre_commit.get_preferred_pre_commit_config_path.return_value = (
             test_folder_path / ".secureli" / ".pre-commit-config.yaml"
+        )
+        mock_hooks_scanner.pre_commit.get_pre_commit_config_path_is_correct.return_value = (
+            False
         )
         verify_result = action.verify_install(
             test_folder_path, reset=False, always_yes=True, files=None
         )
+        assert verify_result.outcome == VerifyOutcome.INSTALL_SUCCEEDED
+
+
+def test_pre_commit_config_created_if_not_exists(
+    action: Action,
+    mock_hooks_scanner: MagicMock,
+    mock_echo: MagicMock,
+):
+    with (
+        patch.object(Path, "exists", return_value=False),
+        patch("builtins.open", mock_open()) as mo,
+    ):
+        mock_hooks_scanner.pre_commit.get_preferred_pre_commit_config_path.return_value = (
+            test_folder_path / ".secureli" / ".pre-commit-config.yaml"
+        )
+        mock_hooks_scanner.pre_commit.pre_commit_config_exists.return_value = False
+        mock_hooks_scanner.pre_commit.get_pre_commit_config_path_is_correct.return_value = (
+            False
+        )
+        verify_result = action.verify_install(
+            test_folder_path, reset=False, always_yes=True, files=None
+        )
+        mo.assert_called_once()
         assert verify_result.outcome == VerifyOutcome.INSTALL_SUCCEEDED
 
 
@@ -457,26 +494,27 @@ def test_that_update_secureli_pre_commit_config_location_moves_file(
         update_file_location, True
     )
     mock_echo.print.assert_called_once_with(
-        "seCureLI's .pre-commit-config.yaml is in a deprecated location."
+        "The .pre-commit-config.yaml is in a deprecated location."
     )
     mock_hooks_scanner.pre_commit.migrate_config_file.assert_called_with(
         update_file_location
     )
     assert update_result.outcome == VerifyOutcome.UPDATE_SUCCEEDED
+    # assert update_result.file_path == update_file_location
 
 
 def test_that_update_secureli_pre_commit_config_fails_on_exception(
     action: Action,
     mock_hooks_scanner: MagicMock,
 ):
-    with pytest.raises(Exception):
-        mock_hooks_scanner.pre_commit.get_preferred_pre_commit_config_path.return_value = (
-            test_folder_path / ".secureli" / ".pre-commit-config.yaml"
-        )
-        update_result = action._update_secureli_pre_commit_config_location(
-            test_folder_path, True
-        )
-        assert update_result.outcome == VerifyOutcome.UPDATE_FAILED
+    mock_hooks_scanner.pre_commit.migrate_config_file.side_effect = Exception("ERROR")
+    mock_hooks_scanner.pre_commit.get_preferred_pre_commit_config_path.return_value = (
+        test_folder_path / ".secureli" / ".pre-commit-config.yaml"
+    )
+    update_result = action._update_secureli_pre_commit_config_location(
+        test_folder_path, True
+    )
+    assert update_result.outcome == VerifyOutcome.UPDATE_FAILED
 
 
 def test_that_update_secureli_pre_commit_config_location_cancels_on_user_response(

--- a/tests/actions/test_action.py
+++ b/tests/actions/test_action.py
@@ -422,7 +422,6 @@ def test_that_verify_install_returns_failure_result_without_pre_commit_config_fi
     mock_hooks_scanner: MagicMock,
     mock_echo: MagicMock,
 ):
-
     with (patch.object(Path, "exists", return_value=False),):
         mock_hooks_scanner.pre_commit.get_preferred_pre_commit_config_path.return_value = (
             test_folder_path / ".secureli" / ".pre-commit-config.yaml"
@@ -458,29 +457,6 @@ def test_that_verify_install_continues_after_pre_commit_config_file_moved(
         verify_result = action.verify_install(
             test_folder_path, reset=False, always_yes=True, files=None
         )
-        assert verify_result.outcome == VerifyOutcome.INSTALL_SUCCEEDED
-
-
-def test_pre_commit_config_created_if_not_exists(
-    action: Action,
-    mock_hooks_scanner: MagicMock,
-    mock_echo: MagicMock,
-):
-    with (
-        patch.object(Path, "exists", return_value=False),
-        patch("builtins.open", mock_open()) as mo,
-    ):
-        mock_hooks_scanner.pre_commit.get_preferred_pre_commit_config_path.return_value = (
-            test_folder_path / ".secureli" / ".pre-commit-config.yaml"
-        )
-        mock_hooks_scanner.pre_commit.pre_commit_config_exists.return_value = False
-        mock_hooks_scanner.pre_commit.get_pre_commit_config_path_is_correct.return_value = (
-            False
-        )
-        verify_result = action.verify_install(
-            test_folder_path, reset=False, always_yes=True, files=None
-        )
-        mo.assert_called_once()
         assert verify_result.outcome == VerifyOutcome.INSTALL_SUCCEEDED
 
 

--- a/tests/end-to-end/testinstallnewhooks.bats
+++ b/tests/end-to-end/testinstallnewhooks.bats
@@ -1,0 +1,22 @@
+# Test to ensure pre-exisiting hooks within the .pre-commit-config.yaml files
+# are persisted when installing secureli
+
+MOCK_REPO='tests/test-data/mock-repo'
+
+setup() {
+  load "${BATS_LIBS_ROOT}/bats-support/load"
+  load "${BATS_LIBS_ROOT}/bats-assert/load"
+  mkdir -p $MOCK_REPO
+  echo 'print("hello world!")' > $MOCK_REPO/hw.py
+  run git init $MOCK_REPO
+}
+
+@test "can preserve pre-existing hooks" {
+    run python secureli/main.py init -y  --directory $MOCK_REPO
+    run grep 'https://github.com/psf/black' $MOCK_REPO/.secureli/.pre-commit-config.yaml
+    assert_output --partial 'https://github.com/psf/black'
+}
+
+teardown() {
+    rm -rf $MOCK_REPO
+}

--- a/tests/end-to-end/testpreservehooks.bats
+++ b/tests/end-to-end/testpreservehooks.bats
@@ -7,10 +7,9 @@ setup() {
   load "${BATS_LIBS_ROOT}/bats-support/load"
   load "${BATS_LIBS_ROOT}/bats-assert/load"
   mkdir -p $MOCK_REPO
-  echo '# Existing YAML Contents should persist' > $MOCK_REPO/.pre-commit-config.yaml
   echo 'repos:' >> $MOCK_REPO/.pre-commit-config.yaml
   echo '-   repo: https://github.com/hhatto/autopep8' >> $MOCK_REPO/.pre-commit-config.yaml
-  echo '    rev: v2.0.4' >> $MOCK_REPO/.pre-commit-config.yaml
+  echo '    rev: v2.1.0' >> $MOCK_REPO/.pre-commit-config.yaml
   echo '    hooks:' >> $MOCK_REPO/.pre-commit-config.yaml
   echo '    -   id: autopep8' >> $MOCK_REPO/.pre-commit-config.yaml
   echo 'fail_fast: false' >> $MOCK_REPO/.pre-commit-config.yaml

--- a/tests/modules/language_analyzer/test_language_support.py
+++ b/tests/modules/language_analyzer/test_language_support.py
@@ -475,6 +475,38 @@ def test_build_pre_commit_respects_existing_pre_commit_config(
         }
 
 
+# def test_build_pre_commit_works_without_existing_pre_commit_config(
+#     language_support_service: language_support.LanguageSupportService,
+#     mock_language_config_service: MagicMock,
+#     mock_open: MagicMock,
+# ):
+#     mock_language_config_service.get_language_config.return_value = language.LanguagePreCommitResult(
+#         language="Python",
+#         version="abc123",
+#         linter_config=language.LoadLinterConfigsResult(
+#             successful=True,
+#             linter_data=[{"filename": "test.txt", "settings": {}}],
+#         ),
+#         config_data="""
+#             repos:
+#             """,
+#     )
+#     mock_data_loader.return_value = ""
+#     languages = ["RadLang"]
+#     lint_languages = [*languages]
+#     with (
+#         patch("builtins.open", mock_open(read_data="data")),
+#         patch.object(
+#             yaml, "safe_load", return_value={"repos": [{"autopep8": {"version": 0}}]}
+#         ),
+#     ):
+#         result = language_support_service.build_pre_commit_config(
+#             languages, lint_languages, test_folder_path
+#         )
+#         assert result.successful == True
+#         assert result.config_data == {"repos": []}
+
+
 def test_write_pre_commit_configs_ignores_empty_linter_arr(
     language_support_service: language_support.LanguageSupportService,
     mock_open: MagicMock,

--- a/tests/modules/language_analyzer/test_language_support.py
+++ b/tests/modules/language_analyzer/test_language_support.py
@@ -475,38 +475,6 @@ def test_build_pre_commit_respects_existing_pre_commit_config(
         }
 
 
-# def test_build_pre_commit_works_without_existing_pre_commit_config(
-#     language_support_service: language_support.LanguageSupportService,
-#     mock_language_config_service: MagicMock,
-#     mock_open: MagicMock,
-# ):
-#     mock_language_config_service.get_language_config.return_value = language.LanguagePreCommitResult(
-#         language="Python",
-#         version="abc123",
-#         linter_config=language.LoadLinterConfigsResult(
-#             successful=True,
-#             linter_data=[{"filename": "test.txt", "settings": {}}],
-#         ),
-#         config_data="""
-#             repos:
-#             """,
-#     )
-#     mock_data_loader.return_value = ""
-#     languages = ["RadLang"]
-#     lint_languages = [*languages]
-#     with (
-#         patch("builtins.open", mock_open(read_data="data")),
-#         patch.object(
-#             yaml, "safe_load", return_value={"repos": [{"autopep8": {"version": 0}}]}
-#         ),
-#     ):
-#         result = language_support_service.build_pre_commit_config(
-#             languages, lint_languages, test_folder_path
-#         )
-#         assert result.successful == True
-#         assert result.config_data == {"repos": []}
-
-
 def test_write_pre_commit_configs_ignores_empty_linter_arr(
     language_support_service: language_support.LanguageSupportService,
     mock_open: MagicMock,

--- a/tests/modules/shared/abstractions/test_pre_commit.py
+++ b/tests/modules/shared/abstractions/test_pre_commit.py
@@ -571,3 +571,15 @@ def test_migrate_config_file_moves_pre_commit_conig(
             f"Moving {old_location} to {new_location}..."
         )
         mock_move.assert_called_once()
+
+
+def test_get_pre_commit_config_path_is_correct_returns_expected_values(
+    pre_commit: PreCommitAbstraction,
+):
+    bad_result = pre_commit.get_pre_commit_config_path_is_correct(test_folder_path)
+    assert bad_result == False
+    with (um.patch.object(Path, "exists", return_value=True),):
+        good_result = pre_commit.get_pre_commit_config_path_is_correct(
+            test_folder_path / ".secureli"
+        )
+        assert good_result == True


### PR DESCRIPTION
secureli-XXX
in a final check on recent work, I noticed that init was failing if there was no .pre-commit-config.yaml. This should fix that issue, maintain new functionality for copying existing yaml settings, and update tests.


## Changes
* Updated action, language_support, and pre_commit to account for a lack of a .pre-commit-config.yaml by creating blank one if it doesn't exist. If it does exist and isn't where we want it, we move it.

## Testing
* all tests pass
* in a dummy repo, run secureli init _with_ a .pre-commit-config.yaml in the root directory
* in a dummy repo, run secureli init _without_ a .pre-commit-config.yaml in the root directory

## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [x] Meets acceptance criteria for issue
- [x] New logic is covered with automated tests
- [ ] Appropriate exception handling added
- [ ] Thoughtful logging included
- [ ] Documentation is updated
- [ ] Follow-up work is documented in TODOs
- [x] TODOs have a ticket associated with them
- [x] No commented-out code included

