### PR TITLE
feat: bugfix for error on init of C# repos

### DIFF
--- a/.secureli/.pre-commit-config.yaml
+++ b/.secureli/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/.secureli/.pre-commit-config.yaml
+++ b/.secureli/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+    rev: 24.4.0
     hooks:
     -   id: black
 -   repo: https://github.com/yelp/detect-secrets

--- a/secureli/repositories/repo_settings.py
+++ b/secureli/repositories/repo_settings.py
@@ -110,7 +110,7 @@ class PreCommitRepo(BaseModel):
     """
 
     url: str = Field(alias="repo")
-    rev: str | None
+    rev: Optional[str]
     hooks: list[PreCommitHook] = Field(default=[])
     suppressed_hook_ids: list[str] = Field(default=[])
 

--- a/secureli/repositories/repo_settings.py
+++ b/secureli/repositories/repo_settings.py
@@ -110,7 +110,7 @@ class PreCommitRepo(BaseModel):
     """
 
     url: str = Field(alias="repo")
-    rev: str
+    rev: str | None
     hooks: list[PreCommitHook] = Field(default=[])
     suppressed_hook_ids: list[str] = Field(default=[])
 


### PR DESCRIPTION
secureli-512

<!-- Include general description here -->
Secureli init failed/errors out on initialization of repo with C# language.  This PR resolves that issue.

## Changes
<!-- A detailed list of changes -->
* Made 'rev' property on pre-commit repo setting optional.

## Testing
<!--
Mention updated tests and any manual testing performed.
Are aspects not yet tested or not easily testable?
Feel free to include screenshots if appropriate.
 -->
* All existing unit tests passing

## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [x] Meets acceptance criteria for issue
- [ ] New logic is covered with automated tests
- [ ] Appropriate exception handling added
- [ ] Thoughtful logging included
- [ ] Documentation is updated
- [ ] Follow-up work is documented in TODOs
- [ ] TODOs have a ticket associated with them
- [x] No commented-out code included


<!--
Github-flavored markdown reference: https://docs.github.com/en/get-started/writing-on-github
-->
