### PR TITLE
chore: change workflow name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -142,11 +142,11 @@ jobs:
         run: ./scripts/secureli-deployment.sh
 
 
-  integration-testing:
-    name: Integration Testing
+  smoke-testing:
+    name: Smoke Testing
     needs: [ build-test, secureli-release, secureli-publish, deploy ]
     if: |
       always() &&
       (needs.secureli-publish.result == 'success' || needs.secureli-publish.result == 'skipped') &&
       (needs.deploy.result == 'success' || needs.deploy.result == 'skipped')
-    uses: ./.github/workflows/integration_testing.yml
+    uses: ./.github/workflows/smoke_testing.yml

--- a/.github/workflows/smoke_testing.yml
+++ b/.github/workflows/smoke_testing.yml
@@ -1,9 +1,7 @@
 # This workflow pulls the published seCureLI packages from Pypi & Homebrew & executes them against a test repo
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-# TODO we should rename these to smoke tests but I'd rather hold off on doing that for now
-# since renaming the workflow/action might cause us to lose history for executions under the old name
-name: Integration Testing
+name: Smoke Testing
 
 on:
   workflow_call:


### PR DESCRIPTION
secureli-437

Changes the name of the integration test workflow to smoke test. 
According to [the issue raised on stack overflow here](https://stackoverflow.com/questions/57927115/delete-a-workflow-from-github-actions#57927776), and [the github documentation here](https://docs.github.com/en/actions/managing-workflow-runs/deleting-a-workflow-run), the old integration test workflow history should remain. Workflow runs must be deleted manually, and renaming the files should create a new workflow.

If the Integration Test workflow is still active after this PR is merged, it should be disabled. [How to disable a workflow](https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-a-workflow)


## Changes
* Rename .github/workflows/integration_testing.yml to .github/workflows/smoke_testing.yml
* Updated workflow name to Smoke Testing
* Updated job name and file reference to Smoke Testing in .github/workflows/publish.yml

## Testing
* Not sure how to test, since this workflow will only run on main and be created when this PR is merged.


## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [X] Meets acceptance criteria for issue
- [ ] New logic is covered with automated tests
- [ ] Appropriate exception handling added
- [ ] Thoughtful logging included
- [ ] Documentation is updated
- [ ] Follow-up work is documented in TODOs
- [ ] TODOs have a ticket associated with them
- [x] No commented-out code included


<!--
Github-flavored markdown reference: https://docs.github.com/en/get-started/writing-on-github
-->
