### PR TITLE
fix: add GitPython to dependencies list

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -408,20 +408,21 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.41"
+version = "3.1.43"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "GitPython-3.1.41-py3-none-any.whl", hash = "sha256:c36b6634d069b3f719610175020a9aed919421c87552185b085e04fbbdb10b7c"},
-    {file = "GitPython-3.1.41.tar.gz", hash = "sha256:ed66e624884f76df22c8e16066d567aaa5a37d5b5fa19db2c6df6f7156db9048"},
+    {file = "GitPython-3.1.43-py3-none-any.whl", hash = "sha256:eec7ec56b92aad751f9912a73404bc02ba212a23adb2c7098ee668417051a1ff"},
+    {file = "GitPython-3.1.43.tar.gz", hash = "sha256:35f314a9f878467f5453cc1fee295c3e18e52f1b99f10f6cf5b1682e968a9e7c"},
 ]
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
 
 [package.extras]
-test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "sumtypes"]
+doc = ["sphinx (==4.3.2)", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphinxcontrib-applehelp (>=1.0.2,<=1.0.4)", "sphinxcontrib-devhelp (==1.0.2)", "sphinxcontrib-htmlhelp (>=2.0.0,<=2.0.1)", "sphinxcontrib-qthelp (==1.0.3)", "sphinxcontrib-serializinghtml (==1.1.5)"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
 
 [[package]]
 name = "identify"
@@ -1177,4 +1178,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.9, < 3.12"
-content-hash = "07e5254748d95bf8523b65289d292c5da4192bf3684dce86d7c0845217cd4f84"
+content-hash = "e9300ef37521f89660f5740260124d5deb5efb0d2a0fbeddc09aa40f6720adc1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ pre-commit = ">=2.20,<4.0"
 requests = "^2.31.0"
 pyyaml = ">=6.0.1"
 chardet = "^5.2.0"
+gitpython = "^3.1.43"
 
 [tool.pytest.ini_options]
 addopts = "-p no:cacheprovider"


### PR DESCRIPTION
secureli-526

Add the GitPython package to our list of dependencies so that Poetry adds it on install.


## Changes
* add gitpython to pyproject.toml
* regenerated lock file with updated gitpython version
* poetry install also made some updates to the extra optional dependencies in the lock file

## Testing
Ran Secureli init after a clean install, it passed

<img width="1101" alt="Screenshot 2024-04-23 at 3 44 54 PM" src="https://github.com/slalombuild/secureli/assets/85907688/66d99d89-679e-4427-8d26-f6392b188484">

Ran Poe Tests
<img width="781" alt="Screenshot 2024-04-23 at 3 45 29 PM" src="https://github.com/slalombuild/secureli/assets/85907688/cb7b7f0d-919f-4291-be2f-2fb9cc2f1da9">

## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [X] Meets acceptance criteria for issue
- [ ] New logic is covered with automated tests
- [ ] Appropriate exception handling added
- [ ] Thoughtful logging included
- [ ] Documentation is updated
- [ ] Follow-up work is documented in TODOs
- [ ] TODOs have a ticket associated with them
- [X] No commented-out code included

