### PR TITLE
feat: Prompted to ReInstall When Running on Branch

### DIFF
--- a/.secureli/.pre-commit-config.yaml
+++ b/.secureli/.pre-commit-config.yaml
@@ -13,6 +13,6 @@ repos:
       hooks:
           - id: black
     - repo: https://github.com/yelp/detect-secrets
-      rev: v1.4.0
+      rev: v1.5.0
       hooks:
           - id: detect-secrets

--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -6,7 +6,7 @@ from secureli.modules.observability.observability_services.logging import Loggin
 from secureli.modules.shared.abstractions.echo import EchoAbstraction
 from secureli.modules.observability.consts.logging import TELEMETRY_DEFAULT_ENDPOINT
 from secureli.modules.shared.models.echo import Color
-from secureli.modules.shared.models.install import VerifyOutcome, VerifyResult
+from secureli.modules.shared.models import install
 from secureli.modules.shared.models import language
 from secureli.modules.shared.models.logging import LogAction
 from secureli.modules.shared.models.scan import ScanMode
@@ -68,7 +68,8 @@ class Action(ABC):
         reset: bool,
         always_yes: bool,
         files: list[Path],
-    ) -> VerifyResult:
+        action_source: install.ActionSource,
+    ) -> install.VerifyResult:
         """
         Installs, upgrades or verifies the current seCureLI installation
         :param folder_path: The folder path to initialize the repo for
@@ -82,9 +83,9 @@ class Action(ABC):
             == ConfigModels.VerifyConfigOutcome.OUT_OF_DATE
         ):
             update_config = self._update_secureli_config_only(always_yes)
-            if update_config.outcome != VerifyOutcome.UPDATE_SUCCEEDED:
+            if update_config.outcome != install.VerifyOutcome.UPDATE_SUCCEEDED:
                 self.action_deps.echo.error("seCureLI could not be verified.")
-                return VerifyResult(
+                return install.VerifyResult(
                     outcome=update_config.outcome,
                 )
         pre_commit_config_location_is_correct = self.action_deps.hooks_scanner.pre_commit.get_pre_commit_config_path_is_correct(
@@ -100,13 +101,13 @@ class Action(ABC):
             and not pre_commit_config_location_is_correct
         )
         if pre_commit_to_preserve:
-            update_result: VerifyResult = (
+            update_result: install.VerifyResult = (
                 self._update_secureli_pre_commit_config_location(
                     folder_path, always_yes
                 )
             )
 
-            if update_result.outcome != VerifyOutcome.UPDATE_SUCCEEDED:
+            if update_result.outcome != install.VerifyOutcome.UPDATE_SUCCEEDED:
                 self.action_deps.echo.error(
                     "seCureLI .pre-commit-config.yaml could not be moved."
                 )
@@ -114,11 +115,15 @@ class Action(ABC):
             else:
                 preferred_config_path = update_result.file_path
 
-        if not pre_commit_config_location_is_correct and not pre_commit_to_preserve:
+        if (
+            not pre_commit_config_location_is_correct
+            and not pre_commit_to_preserve
+            and action_source == install.ActionSource.SCAN
+        ):
             self.action_deps.echo.error(
                 "seCureLI has not been initialized on this branch."
             )
-            return VerifyResult(outcome=VerifyOutcome.INSTALL_FAILED)
+            return install.VerifyResult(outcome=install.VerifyOutcome.INSTALL_FAILED)
 
         config = self.get_secureli_config(reset=reset)
         languages = []
@@ -130,13 +135,15 @@ class Action(ABC):
                 self.action_deps.echo.warning(
                     f"Newly detected languages are unsupported by seCureLI"
                 )
-                return VerifyResult(outcome=VerifyOutcome.UP_TO_DATE, config=config)
+                return install.VerifyResult(
+                    outcome=install.VerifyOutcome.UP_TO_DATE, config=config
+                )
 
             self.action_deps.echo.error(
                 f"seCureLI could not be installed due to an error: {str(e)}"
             )
-            return VerifyResult(
-                outcome=VerifyOutcome.INSTALL_FAILED,
+            return install.VerifyResult(
+                outcome=install.VerifyOutcome.INSTALL_FAILED,
             )
 
         newly_detected_languages = [
@@ -163,8 +170,8 @@ class Action(ABC):
                     f"following language(s): {format_sentence_list(languages)}"
                 )
             )
-            return VerifyResult(
-                outcome=VerifyOutcome.UP_TO_DATE,
+            return install.VerifyResult(
+                outcome=install.VerifyOutcome.UP_TO_DATE,
                 config=config,
             )
 
@@ -175,7 +182,7 @@ class Action(ABC):
         install_languages: list[str],
         always_yes: bool,
         pre_commit_config_location: Path = None,
-    ) -> VerifyResult:
+    ) -> install.VerifyResult:
         """
         Installs seCureLI into the given folder path and returns the new configuration
         :param folder_path: The folder path to initialize the repo for
@@ -193,12 +200,12 @@ class Action(ABC):
         if not should_install:
             if new_install:
                 self.action_deps.echo.error("User canceled install process")
-                return VerifyResult(
-                    outcome=VerifyOutcome.INSTALL_CANCELED,
+                return install.VerifyResult(
+                    outcome=install.VerifyOutcome.INSTALL_CANCELED,
                 )
 
             self.action_deps.echo.warning("Newly detected languages were not installed")
-            return VerifyResult(outcome=VerifyOutcome.UP_TO_DATE)
+            return install.VerifyResult(outcome=install.VerifyOutcome.UP_TO_DATE)
 
         settings = self.action_deps.settings.load(folder_path)
 
@@ -242,8 +249,8 @@ class Action(ABC):
             color=Color.CYAN,
             bold=True,
         )
-        return VerifyResult(
-            outcome=VerifyOutcome.INSTALL_SUCCEEDED,
+        return install.VerifyResult(
+            outcome=install.VerifyOutcome.INSTALL_SUCCEEDED,
             config=config,
         )
 
@@ -385,7 +392,7 @@ class Action(ABC):
 
         return lint_languages
 
-    def _update_secureli(self, always_yes: bool) -> VerifyResult:
+    def _update_secureli(self, always_yes: bool) -> install.VerifyResult:
         """
         Prompts the user to update to the latest secureli install.
         :param always_yes: Assume "Yes" to all prompts
@@ -400,7 +407,7 @@ class Action(ABC):
 
         if not update_confirmed:
             self.action_deps.echo.print("\nUpdate declined.\n")
-            return VerifyResult(outcome=VerifyOutcome.UPDATE_CANCELED)
+            return install.VerifyResult(outcome=install.VerifyOutcome.UPDATE_CANCELED)
 
         update_result = self.action_deps.updater.update()
         details = update_result.output
@@ -408,11 +415,11 @@ class Action(ABC):
             self.action_deps.echo.print(details)
 
         if update_result.successful:
-            return VerifyResult(outcome=VerifyOutcome.UPDATE_SUCCEEDED)
+            return install.VerifyResult(outcome=install.VerifyOutcome.UPDATE_SUCCEEDED)
         else:
-            return VerifyResult(outcome=VerifyOutcome.UPDATE_FAILED)
+            return install.VerifyResult(outcome=install.VerifyOutcome.UPDATE_FAILED)
 
-    def _update_secureli_config_only(self, always_yes: bool) -> VerifyResult:
+    def _update_secureli_config_only(self, always_yes: bool) -> install.VerifyResult:
         self.action_deps.echo.print("seCureLI is using an out-of-date config.")
         response = always_yes or self.action_deps.echo.confirm(
             "Update configuration now?",
@@ -420,21 +427,21 @@ class Action(ABC):
         )
         if not response:
             self.action_deps.echo.error("User canceled update process")
-            return VerifyResult(
-                outcome=VerifyOutcome.UPDATE_CANCELED,
+            return install.VerifyResult(
+                outcome=install.VerifyOutcome.UPDATE_CANCELED,
             )
 
         try:
             updated_config = self.action_deps.secureli_config.update()
             self.action_deps.secureli_config.save(updated_config)
 
-            return VerifyResult(outcome=VerifyOutcome.UPDATE_SUCCEEDED)
+            return install.VerifyResult(outcome=install.VerifyOutcome.UPDATE_SUCCEEDED)
         except:
-            return VerifyResult(outcome=VerifyOutcome.UPDATE_FAILED)
+            return install.VerifyResult(outcome=install.VerifyOutcome.UPDATE_FAILED)
 
     def _update_secureli_pre_commit_config_location(
         self, folder_path: Path, always_yes: bool
-    ) -> VerifyResult:
+    ) -> install.VerifyResult:
         """
         In order to provide an upgrade path for existing users of secureli,
         we will prompt users to move their .pre-commit-config.yaml into the .secureli/ directory.
@@ -459,11 +466,12 @@ class Action(ABC):
                         folder_path
                     )
                 )
-                return VerifyResult(
-                    outcome=VerifyOutcome.UPDATE_SUCCEEDED, file_path=new_file_path
+                return install.VerifyResult(
+                    outcome=install.VerifyOutcome.UPDATE_SUCCEEDED,
+                    file_path=new_file_path,
                 )
             except:
-                return VerifyResult(outcome=VerifyOutcome.UPDATE_FAILED)
+                return install.VerifyResult(outcome=install.VerifyOutcome.UPDATE_FAILED)
         else:
             self.action_deps.echo.warning(".pre-commit-config.yaml migration declined")
             deprecated_location = (
@@ -471,8 +479,9 @@ class Action(ABC):
                     folder_path
                 )
             )
-            return VerifyResult(
-                outcome=VerifyOutcome.UPDATE_CANCELED, file_path=deprecated_location
+            return install.VerifyResult(
+                outcome=install.VerifyOutcome.UPDATE_CANCELED,
+                file_path=deprecated_location,
             )
 
     def _initial_hooks_update(self, folder_path: Path):

--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -258,14 +258,14 @@ class Action(ABC):
         self, languages: list[str], always_yes: bool, new_install: bool
     ) -> bool:
         """
-        Prompts user to determine if secureli should be installed or not
+        Prompts user to determine if secureli should be initialized or not
         :param languages: List of language names to display
         :param always_yes: Assume "Yes" to all prompts
         :param new_install: Used to determine if the install is new or
         if additional languages are being added
         """
 
-        new_install_message = "seCureLI has not yet been installed, install now?"
+        new_install_message = "seCureLI has not yet been initialized, initialize now?"
         add_languages_message = (
             f"seCureLI has not been installed for the following language(s): "
             f"{format_sentence_list(languages)}, install now?"

--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -114,6 +114,12 @@ class Action(ABC):
             else:
                 preferred_config_path = update_result.file_path
 
+        if not pre_commit_config_location_is_correct and not pre_commit_to_preserve:
+            self.action_deps.echo.error(
+                "seCureLI has not been initialized on this branch."
+            )
+            return VerifyResult(outcome=VerifyOutcome.INSTALL_FAILED)
+
         config = self.get_secureli_config(reset=reset)
         languages = []
 

--- a/secureli/actions/initializer.py
+++ b/secureli/actions/initializer.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from secureli.actions.scan import ScanAction
 from secureli.actions.action import Action, ActionDependencies
 from secureli.modules.observability.observability_services.logging import LoggingService
-from secureli.modules.shared.models.install import VerifyResult
+from secureli.modules.shared.models.install import ActionSource, VerifyResult
 from secureli.modules.shared.models.logging import LogAction
 
 
@@ -25,7 +25,13 @@ class InitializerAction(Action):
         :param reset: If true, disregard existing configuration and start fresh
         :param always_yes: Assume "Yes" to all prompts
         """
-        verify_result = self.verify_install(folder_path, reset, always_yes, files=None)
+        verify_result = self.verify_install(
+            folder_path,
+            reset,
+            always_yes,
+            files=None,
+            action_source=ActionSource.INITIALIZER,
+        )
         if verify_result.outcome in ScanAction.halting_outcomes:
             self.action_deps.logging.failure(LogAction.init, verify_result.outcome)
         else:

--- a/secureli/actions/scan.py
+++ b/secureli/actions/scan.py
@@ -8,7 +8,7 @@ from secureli.modules.shared.abstractions.echo import EchoAbstraction
 from secureli.actions import action
 from secureli.modules.shared.abstractions.repo import GitRepo
 from secureli.modules.shared.models.exit_codes import ExitCode
-from secureli.modules.shared.models.install import VerifyOutcome, VerifyResult
+from secureli.modules.shared.models import install
 from secureli.modules.shared.models.logging import LogAction
 from secureli.modules.shared.models.publish_results import PublishResultsOption
 from secureli.modules.shared.models.result import Result
@@ -27,10 +27,10 @@ class ScanAction(action.Action):
 
     """Any verification outcomes that would cause us to not proceed to scan."""
     halting_outcomes = [
-        VerifyOutcome.INSTALL_FAILED,
-        VerifyOutcome.INSTALL_CANCELED,
-        VerifyOutcome.UPDATE_FAILED,
-        VerifyOutcome.UPDATE_CANCELED,
+        install.VerifyOutcome.INSTALL_FAILED,
+        install.VerifyOutcome.INSTALL_CANCELED,
+        install.VerifyOutcome.UPDATE_FAILED,
+        install.VerifyOutcome.UPDATE_CANCELED,
     ]
 
     def __init__(
@@ -99,6 +99,7 @@ class ScanAction(action.Action):
             False,
             always_yes,
             scan_files,
+            action_source=install.ActionSource.SCAN,
         )
 
         # Check if pre-commit hooks are up-to-date
@@ -160,7 +161,7 @@ class ScanAction(action.Action):
         else:
             sys.exit(ExitCode.SCAN_ISSUES_DETECTED.value)
 
-    def _check_secureli_hook_updates(self, folder_path: Path) -> VerifyResult:
+    def _check_secureli_hook_updates(self, folder_path: Path) -> install.VerifyResult:
         """
         Queries repositories referenced by pre-commit hooks to check
         if we have the latest revisions listed in the .pre-commit-config.yaml file
@@ -178,7 +179,7 @@ class ScanAction(action.Action):
 
         if not repos_to_update:
             self.action_deps.echo.print("No hooks to update")
-            return VerifyResult(outcome=VerifyOutcome.UP_TO_DATE)
+            return install.VerifyResult(outcome=install.VerifyOutcome.UP_TO_DATE)
 
         for repo, revs in repos_to_update.items():
             self.action_deps.echo.debug(
@@ -188,7 +189,7 @@ class ScanAction(action.Action):
             "You have out-of-date pre-commit hooks. Run `secureli update` to update them."
         )
         # Since we don't actually perform the updates here, return an outcome of UPDATE_CANCELLED
-        return VerifyResult(outcome=VerifyOutcome.UPDATE_CANCELED)
+        return install.VerifyResult(outcome=install.VerifyOutcome.UPDATE_CANCELED)
 
     def _get_commited_files(self, scan_mode: ScanMode) -> list[Path]:
         """

--- a/secureli/modules/shared/models/install.py
+++ b/secureli/modules/shared/models/install.py
@@ -17,6 +17,11 @@ class VerifyOutcome(str, Enum):
     UP_TO_DATE = "up-to-date"
 
 
+class ActionSource(str, Enum):
+    INITIALIZER = "initializer"
+    SCAN = "scan"
+
+
 class VerifyResult(pydantic.BaseModel):
     """
     The outcomes of performing verification. Actions can use these results

--- a/tests/actions/test_action.py
+++ b/tests/actions/test_action.py
@@ -472,6 +472,28 @@ def test_that_verify_install_continues_after_pre_commit_config_file_moved(
         assert verify_result.outcome == VerifyOutcome.INSTALL_SUCCEEDED
 
 
+def test_that_verify_install_returns_failure_without_pre_commit_file(
+    action: Action,
+    mock_hooks_scanner: MagicMock,
+    mock_echo: MagicMock,
+):
+    with (patch.object(Path, "exists", return_value=True),):
+        mock_hooks_scanner.pre_commit.get_preferred_pre_commit_config_path.return_value = (
+            test_folder_path / ".secureli" / ".pre-commit-config.yaml"
+        )
+        mock_hooks_scanner.pre_commit.get_pre_commit_config_path_is_correct.return_value = (
+            False
+        )
+        mock_hooks_scanner.pre_commit.pre_commit_config_exists.return_value = False
+        verify_result = action.verify_install(
+            test_folder_path, reset=False, always_yes=True, files=None
+        )
+        mock_echo.error.assert_called_once_with(
+            "seCureLI has not been initialized on this branch."
+        )
+        assert verify_result.outcome == VerifyOutcome.INSTALL_FAILED
+
+
 def test_that_update_secureli_pre_commit_config_location_moves_file(
     action: Action,
     mock_hooks_scanner: MagicMock,

--- a/tests/actions/test_action.py
+++ b/tests/actions/test_action.py
@@ -794,7 +794,7 @@ def test_that_prompt_to_install_asks_new_install_msg(
     action._prompt_to_install(mock_languages, always_yes=False, new_install=True)
 
     mock_echo.confirm.assert_called_once_with(
-        "seCureLI has not yet been installed, install now?", default_response=True
+        "seCureLI has not yet been initialized, initialize now?", default_response=True
     )
 
 

--- a/tests/actions/test_action.py
+++ b/tests/actions/test_action.py
@@ -7,7 +7,7 @@ from secureli.modules.shared.abstractions.pre_commit import InstallResult
 from secureli.actions.action import Action, ActionDependencies
 from secureli.modules.observability.consts.logging import TELEMETRY_DEFAULT_ENDPOINT
 from secureli.modules.shared.models.echo import Color
-from secureli.modules.shared.models.install import VerifyOutcome
+from secureli.modules.shared.models.install import ActionSource, VerifyOutcome
 from secureli.modules.shared.models import language
 from secureli.modules.shared.models.logging import LogAction
 import secureli.modules.shared.models.repository as RepositoryModels
@@ -67,7 +67,13 @@ def test_that_initialize_repo_raises_value_error_without_any_supported_languages
         language_proportions={}, skipped_files=[]
     )
 
-    action.verify_install(test_folder_path, reset=True, always_yes=True, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=True,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     mock_echo.error.assert_called_with(
         "seCureLI could not be installed due to an error: No supported languages found in current repository"
@@ -87,7 +93,13 @@ def test_that_initialize_repo_install_flow_selects_both_languages(
         skipped_files=[],
     )
 
-    action.verify_install(test_folder_path, reset=True, always_yes=True, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=True,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     mock_echo.print.assert_called_with(
         "seCureLI has been installed successfully for the following language(s): RadLang and CoolLang.\n",
@@ -109,7 +121,13 @@ def test_that_initialize_repo_install_flow_performs_security_analysis(
         skipped_files=[],
     )
 
-    action.verify_install(test_folder_path, reset=True, always_yes=True, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=True,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     mock_hooks_scanner.scan_repo.assert_called_once()
 
@@ -122,7 +140,13 @@ def test_that_initialize_repo_install_flow_displays_security_analysis_results(
         output="Detect secrets...Failed",
         failures=[ScanFailure(repo="repo", id="id", file="file")],
     )
-    action.verify_install(test_folder_path, reset=True, always_yes=True, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=True,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     action_deps.echo.print.assert_any_call("Detect secrets...Failed")
 
@@ -144,7 +168,13 @@ def test_that_initialize_repo_install_flow_skips_security_analysis_if_unavailabl
         version="abc123", security_hook_id=None
     )
 
-    action.verify_install(test_folder_path, reset=True, always_yes=True, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=True,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     mock_hooks_scanner.scan_repo.assert_not_called()
 
@@ -175,7 +205,13 @@ def test_that_initialize_repo_install_flow_warns_about_skipped_files(
         successful=True, backup_hook_path=None
     )
 
-    action.verify_install(test_folder_path, reset=True, always_yes=True, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=True,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     assert (
         mock_echo.warning.call_count == 3
@@ -193,7 +229,11 @@ def test_that_initialize_repo_can_be_canceled(
     )
     with (patch.object(Path, "exists", return_value=True),):
         action.verify_install(
-            test_folder_path, reset=True, always_yes=False, files=None
+            test_folder_path,
+            reset=True,
+            always_yes=False,
+            files=None,
+            action_source=ActionSource.INITIALIZER,
         )
 
         mock_echo.error.assert_called_with("User canceled install process")
@@ -215,7 +255,13 @@ def test_that_initialize_repo_selects_previously_selected_language(
     )
     mock_language_support.version_for_language.return_value = "abc123"
 
-    action.verify_install(test_folder_path, reset=False, always_yes=True, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=False,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     mock_echo.print.assert_called_with(
         "seCureLI is installed and up-to-date for the following language(s): PreviousLang"
@@ -235,7 +281,13 @@ def test_that_initialize_repo_prompts_to_upgrade_config_if_old_schema(
     mock_language_support.version_for_language.return_value = "xyz987"
     mock_echo.confirm.return_value = False
 
-    action.verify_install(test_folder_path, reset=False, always_yes=False, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=False,
+        always_yes=False,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     mock_echo.error.assert_called_with("seCureLI could not be verified.")
 
@@ -265,7 +317,11 @@ def test_that_initialize_repo_updates_repo_config_if_old_schema(
     mock_language_support.version_for_language.return_value = "abc123"
 
     result = action.verify_install(
-        test_folder_path, reset=False, always_yes=True, files=None
+        test_folder_path,
+        reset=False,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
     )
 
     assert result.outcome == VerifyOutcome.UP_TO_DATE
@@ -283,7 +339,13 @@ def test_that_initialize_repo_reports_errors_when_schema_update_fails(
 
     mock_secureli_config.update.side_effect = Exception
 
-    action.verify_install(test_folder_path, reset=False, always_yes=True, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=False,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     mock_echo.error.assert_called_with("seCureLI could not be verified.")
 
@@ -300,7 +362,13 @@ def test_that_initialize_repo_is_aborted_by_the_user_if_the_process_is_canceled(
         ConfigModels.SecureliConfig()
     )  # fresh config
 
-    action.verify_install(test_folder_path, reset=False, always_yes=False, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=False,
+        always_yes=False,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     mock_echo.error.assert_called_with("User canceled install process")
 
@@ -321,7 +389,11 @@ def test_that_initialize_repo_returns_up_to_date_if_the_process_is_canceled_on_e
     )
 
     result = action.verify_install(
-        test_folder_path, reset=False, always_yes=False, files=None
+        test_folder_path,
+        reset=False,
+        always_yes=False,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
     )
     assert result.outcome == VerifyOutcome.UP_TO_DATE
 
@@ -344,7 +416,13 @@ def test_that_initialize_repo_prints_warnings_for_failed_linter_config_writes(
         successful=True, backup_hook_path=None
     )
 
-    action.verify_install(test_folder_path, reset=True, always_yes=True, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=True,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     mock_echo.warning.assert_called_once_with(config_write_error)
 
@@ -363,7 +441,11 @@ def test_that_verify_install_returns_failed_result_on_new_install_language_not_s
     )
 
     verify_result = action.verify_install(
-        test_folder_path, reset=False, always_yes=False, files=None
+        test_folder_path,
+        reset=False,
+        always_yes=False,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
     )
 
     assert verify_result.outcome == VerifyOutcome.INSTALL_FAILED
@@ -383,7 +465,11 @@ def test_that_verify_install_returns_up_to_date_result_on_existing_install_langu
     )
 
     verify_result = action.verify_install(
-        test_folder_path, reset=False, always_yes=False, files=None
+        test_folder_path,
+        reset=False,
+        always_yes=False,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
     )
 
     assert verify_result.outcome == VerifyOutcome.UP_TO_DATE
@@ -403,7 +489,11 @@ def test_that_verify_install_returns_up_to_date_result_on_existing_install_no_ne
     )
 
     verify_result = action.verify_install(
-        test_folder_path, reset=False, always_yes=False, files=None
+        test_folder_path,
+        reset=False,
+        always_yes=False,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
     )
 
     assert verify_result.outcome == VerifyOutcome.UP_TO_DATE
@@ -423,7 +513,11 @@ def test_that_verify_install_returns_success_result_newly_detected_language_inst
     )
 
     verify_result = action.verify_install(
-        test_folder_path, reset=False, always_yes=True, files=None
+        test_folder_path,
+        reset=False,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
     )
 
     assert verify_result.outcome == VerifyOutcome.INSTALL_SUCCEEDED
@@ -446,7 +540,11 @@ def test_that_verify_install_returns_failure_result_without_pre_commit_config_fi
         )
 
         verify_result = action.verify_install(
-            test_folder_path, reset=False, always_yes=True, files=None
+            test_folder_path,
+            reset=False,
+            always_yes=True,
+            files=None,
+            action_source=ActionSource.INITIALIZER,
         )
         mock_echo.error.assert_called_once_with(
             "seCureLI .pre-commit-config.yaml could not be moved."
@@ -467,12 +565,16 @@ def test_that_verify_install_continues_after_pre_commit_config_file_moved(
             False
         )
         verify_result = action.verify_install(
-            test_folder_path, reset=False, always_yes=True, files=None
+            test_folder_path,
+            reset=False,
+            always_yes=True,
+            files=None,
+            action_source=ActionSource.INITIALIZER,
         )
         assert verify_result.outcome == VerifyOutcome.INSTALL_SUCCEEDED
 
 
-def test_that_verify_install_returns_failure_without_pre_commit_file(
+def test_that_verify_install_returns_failure_without_pre_commit_file_on_scan(
     action: Action,
     mock_hooks_scanner: MagicMock,
     mock_echo: MagicMock,
@@ -486,7 +588,11 @@ def test_that_verify_install_returns_failure_without_pre_commit_file(
         )
         mock_hooks_scanner.pre_commit.pre_commit_config_exists.return_value = False
         verify_result = action.verify_install(
-            test_folder_path, reset=False, always_yes=True, files=None
+            test_folder_path,
+            reset=False,
+            always_yes=True,
+            files=None,
+            action_source=ActionSource.SCAN,
         )
         mock_echo.error.assert_called_once_with(
             "seCureLI has not been initialized on this branch."
@@ -564,7 +670,13 @@ def test_that_initialize_repo_install_flow_warns_about_overwriting_pre_commit_fi
 
     mock_updater.pre_commit.install.return_value = install_result
 
-    action.verify_install(test_folder_path, reset=True, always_yes=True, files=None)
+    action.verify_install(
+        test_folder_path,
+        reset=True,
+        always_yes=True,
+        files=None,
+        action_source=ActionSource.INITIALIZER,
+    )
 
     mock_echo.warning.assert_called_once_with(
         (


### PR DESCRIPTION
secureli-537

<!-- Include general description here -->
Fixed bug that says "seCureLI is installed and up-to-date for the following language(s)", even though seCureLI is not initialized completely in that branch. This is an edge case where seCureLI has been installed on one branch, but not on the other branch in the same directory due to seCureLI artifacts that are git ignored.

## Changes
<!-- A detailed list of changes -->
* Added messaging and stop of secureli process when this edge case occurs.
* Updated detect-secret hook version

## Testing
<!--
Mention updated tests and any manual testing performed.
Are aspects not yet tested or not easily testable?
Feel free to include screenshots if appropriate.
 -->
* Added required tests
* All existing tests are passing

## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [ ] Meets acceptance criteria for issue
- [ ] New logic is covered with automated tests
- [ ] Appropriate exception handling added
- [ ] Thoughtful logging included
- [ ] Documentation is updated
- [ ] Follow-up work is documented in TODOs
- [ ] TODOs have a ticket associated with them
- [ ] No commented-out code included


<!--
Github-flavored markdown reference: https://docs.github.com/en/get-started/writing-on-github
-->
