### PR TITLE
fix: Precommit config overwritten on init

### DIFF
--- a/.secureli.yaml
+++ b/.secureli.yaml
@@ -9,5 +9,8 @@ repo_files:
   - .png
   - .jpg
   max_file_size: 1000000
+scan_patterns:
+  custom_scan_patterns:
+  - foo
 telemetry:
   api_url: https://log-api.newrelic.com/log/v1

--- a/.secureli.yaml
+++ b/.secureli.yaml
@@ -9,8 +9,5 @@ repo_files:
   - .png
   - .jpg
   max_file_size: 1000000
-scan_patterns:
-  custom_scan_patterns:
-  - foo
 telemetry:
   api_url: https://log-api.newrelic.com/log/v1

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one -
 - [Usage](#usage)
   - [Help](#help)
   - [Init](#init)
+    - [Preserving Pre-Commit Config](#preserving-pre-commit-config)
   - [Scan](#scan)
     - [Scanned Files](#scanned-files)
     - [PII Scan](#pii-scan)
@@ -115,6 +116,10 @@ All you need to do is run:
 ```
 
 Running `secureli init` will allow seCureLI to detect the languages in your repo, install pre-commit, install all the appropriate pre-commit hooks for your local repo, run a scan for secrets in your local repo, and update the installed hooks.
+
+#### Preserving Pre-Commit Config
+
+If you have an existing pre-commit config file you want to preserve when running `secureli init`, you can use the `--preserve-precommit-config` flag. This is useful for example when checking out a repo with an existing pre-commit config file.
 
 ### Scan
 

--- a/secureli/actions/action.py
+++ b/secureli/actions/action.py
@@ -69,6 +69,7 @@ class Action(ABC):
         always_yes: bool,
         files: list[Path],
         action_source: install.ActionSource,
+        preserve_precommit_config: bool = False,
     ) -> install.VerifyResult:
         """
         Installs, upgrades or verifies the current seCureLI installation
@@ -77,6 +78,8 @@ class Action(ABC):
         :param always_yes: Assume "Yes" to all prompts
         :param files: A List of files to scope the install to. This allows language
         detection to run on only a selected list of files when scanning the repo.
+        :param action_source: The source of the action
+        :param preserve_precommit_config: If true, preserve the existing pre-commit configuration
         """
 
         is_config_out_of_date = (
@@ -163,6 +166,7 @@ class Action(ABC):
                 newly_detected_languages,
                 always_yes,
                 preferred_config_path if pre_commit_to_preserve else None,
+                preserve_precommit_config,
             )
         else:
             self.action_deps.echo.print(
@@ -195,6 +199,7 @@ class Action(ABC):
         install_languages: list[str],
         always_yes: bool,
         pre_commit_config_location: Path = None,
+        preserve_precommit_config: bool = False,
     ) -> install.VerifyResult:
         """
         Installs seCureLI into the given folder path and returns the new configuration
@@ -202,6 +207,8 @@ class Action(ABC):
         :param detected_languages: list of all languages found in the repo
         :param install_languages: list of specific langugages to install secureli features for
         :param always_yes: Assume "Yes" to all prompts
+        :param pre_commit_config_location: The location of the pre-commit config file
+        :param preserve_precommit_config: If true, preserve the existing pre-commit configuration
         :return: The new SecureliConfig after install or None if installation did not complete
         """
 
@@ -230,6 +237,7 @@ class Action(ABC):
             install_languages,
             language_config_result,
             new_install,
+            preserve_precommit_config,
         )
 
         for error_msg in metadata.linter_config_write_errors:

--- a/secureli/actions/initializer.py
+++ b/secureli/actions/initializer.py
@@ -17,13 +17,18 @@ class InitializerAction(Action):
         super().__init__(action_deps)
 
     def initialize_repo(
-        self, folder_path: Path, reset: bool, always_yes: bool
+        self,
+        folder_path: Path,
+        reset: bool,
+        always_yes: bool,
+        preserve_precommit_config: bool = False,
     ) -> VerifyResult:
         """
         Initializes seCureLI for the specified folder path
         :param folder_path: The folder path to initialize the repo for
         :param reset: If true, disregard existing configuration and start fresh
         :param always_yes: Assume "Yes" to all prompts
+        :param preserve_precommit_config: If true, preserve the existing pre-commit configuration
         """
         verify_result = self.verify_install(
             folder_path,
@@ -31,6 +36,7 @@ class InitializerAction(Action):
             always_yes,
             files=None,
             action_source=ActionSource.INITIALIZER,
+            preserve_precommit_config=preserve_precommit_config,
         )
         if verify_result.outcome in ScanAction.halting_outcomes:
             self.action_deps.logging.failure(LogAction.init, verify_result.outcome)

--- a/secureli/main.py
+++ b/secureli/main.py
@@ -91,6 +91,11 @@ def init(
             help="Run secureli against a specific directory",
         ),
     ] = Path("."),
+    preserve_precommit_config: bool = Option(
+        False,
+        "--preserve-precommit-config",
+        help="Preserve the existing pre-commit configuration",
+    ),
 ):
     """
     Detect languages and initialize pre-commit hooks and linters for the project
@@ -98,7 +103,7 @@ def init(
     SecureliConfig.FOLDER_PATH = Path(directory)
 
     init_result = container.initializer_action().initialize_repo(
-        Path(directory), reset, yes
+        Path(directory), reset, yes, preserve_precommit_config
     )
     if init_result.outcome in [
         VerifyOutcome.UP_TO_DATE,

--- a/secureli/modules/language_analyzer/language_support.py
+++ b/secureli/modules/language_analyzer/language_support.py
@@ -37,12 +37,14 @@ class LanguageSupportService:
         languages: list[str],
         language_config_result: language.BuildConfigResult,
         overwrite_pre_commit: bool,
+        preserve_precommit_config: bool = False,
     ) -> language.LanguageMetadata:
         """
         Applies Secure Build support for the provided languages
         :param languages: list of languages to provide support for
         :param language_config_result: resulting config from language hook detection
         :param overwrite_pre_commit: flag to determine if config should overwrite or append to config file
+        :param preserve_precommit_config: If true, preserve the existing pre-commit configuration
         :raises LanguageNotSupportedError if support for the language is not provided
         :return: Metadata including version of the language configuration that was just installed
         as well as a secret-detection hook ID, if present.
@@ -58,14 +60,15 @@ class LanguageSupportService:
             language_config_result.linter_configs
         )
 
-        pre_commit_file_mode = "w" if overwrite_pre_commit else "a"
-        with open(path_to_pre_commit_file, pre_commit_file_mode) as f:
-            data = (
-                language_config_result.config_data
-                if overwrite_pre_commit
-                else language_config_result.config_data["repos"]
-            )
-            f.write(yaml.dump(data))
+        if not preserve_precommit_config:
+            pre_commit_file_mode = "w" if overwrite_pre_commit else "a"
+            with open(path_to_pre_commit_file, pre_commit_file_mode) as f:
+                data = (
+                    language_config_result.config_data
+                    if overwrite_pre_commit
+                    else language_config_result.config_data["repos"]
+                )
+                f.write(yaml.dump(data))
 
         # Add .secureli/ to the gitignore folder if needed
         self.git_ignore.ignore_secureli_files()


### PR DESCRIPTION
secureli-570

An existing precommit config file will be overwritten when running `secureli init`.

I've added a flag to the init action to prevent overwriting the config-- `secureli init --preserve-precommit-config'


## Changes
* Added `--preserve-precommit-config` parameter to init action

## Testing
* Added copy of existing test with the flag added

## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [x] Meets acceptance criteria for issue
- [x] New logic is covered with automated tests
- [ ] Appropriate exception handling added
- [ ] Thoughtful logging included
- [x] Documentation is updated
- [ ] Follow-up work is documented in TODOs
- [ ] TODOs have a ticket associated with them
- [x] No commented-out code included


<!--
Github-flavored markdown reference: https://docs.github.com/en/get-started/writing-on-github
-->
