### PR TITLE
created mock to override file open

### DIFF
--- a/tests/application/test_main.py
+++ b/tests/application/test_main.py
@@ -167,7 +167,19 @@ def test_that_scan_implements_multiple_file_args(mock_container: MagicMock):
     )
 
 
-def test_that_update_with_new_pattern_succeeds():
+@pytest.fixture()
+def mock_secureli_yaml_open_fn(mocker: MockerFixture) -> MagicMock:
+    mock_open = mocker.mock_open(
+        read_data="""
+        {}
+      """
+    )
+    return mocker.patch("builtins.open", mock_open)
+
+
+def test_that_update_with_new_pattern_succeeds(
+    mock_secureli_yaml_open_fn: MagicMock,  # so we don't open and write to the actual secureli.yaml file
+):
     result = CliRunner().invoke(secureli.main.app, ["update", "--new-pattern", "foo"])
     assert result.exit_code == 0
     assert result.stdout == ""


### PR DESCRIPTION
This PR mocks the builtins.open for the test_that_update_with_new_pattern_succeeds test so that the test doesn't open and modify the actual secureli.yaml file in the repository

Tested that all tests still pass and that the secureli file is no longer modified after running tests

## Clean Code Checklist
<!-- This is here to support you. Some/most checkboxes may not apply to your change -->
- [ ] Meets acceptance criteria for issue
- [ ] New logic is covered with automated tests
- [ ] Appropriate exception handling added
- [ ] Thoughtful logging included
- [ ] Documentation is updated
- [ ] Follow-up work is documented in TODOs
- [ ] TODOs have a ticket associated with them
- [ ] No commented-out code included


<!--
Github-flavored markdown reference: https://docs.github.com/en/get-started/writing-on-github
-->
